### PR TITLE
use high-level API

### DIFF
--- a/lib/projfs_i.h
+++ b/lib/projfs_i.h
@@ -30,6 +30,7 @@ struct projfs {
 	void *user_data;
 	pthread_mutex_t mutex;
 	struct fuse_session *session;
+	int lowerdir_fd;
 	pthread_t thread_id;
 	int error;
 };


### PR DESCRIPTION
From the [`fuse` mailing list](https://sourceforge.net/p/fuse/mailman/message/31925484/):

> The fuse kernel interface works on inodes and the low level interface reflects this. The high level interface works on paths and has to translate between inodes and path. That takes memory and cpu to do.
> 
> BUT, what would be the point of using the low level interface if you then need to translate those inode numbers to paths yourself? Do you think you can translate them faster using less resources? Less bugs?
>
> IMHO the low level interface is best when implementing an actual filesystem based on inodes where you don't do any mapping from inode to path.
> 
> For all the pass through filesystems that translate fuse operations to operations of an underlying filesystem (e.g. unionfs-fuse) the highlevel interface is far better suited.

We're running into fd limits with the current code, so let FUSE take care of it instead.