### PR TITLE
update docker/VFSForGit submodule to current linuxprototype HEAD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker/VFSForGit"]
+	path = docker/VFSForGit
+	url = https://github.com/github/VFSForGit.git


### PR DESCRIPTION
There may have been a more elegant way to do this, @kivikakk, but I couldn't find it and just went the brute-force route; I kept getting errors like `Needed a single revision` or `Server does not allow request for unadvertised object`.  (Possibly I needed to refresh `.git/modules/VFSForGit/...`.)

If there's a tidier way to update -- and assuming you think an update is appropriate -- by all means propose something else in another PR!