### PR TITLE
set gitattributes for linguist code detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+docker/Dockerfile-*	linguist-language=Dockerfile
+m4/*			linguist-vendored
+t/t???/*		linguist-detectable=false
+t/chainlint.sed		linguist-vendored
+t/test-lib.sh		linguist-vendored
+t/test-lib-functions.sh	linguist-vendored
+tap-driver.sh		linguist-vendored
+test-driver		linguist-vendored


### PR DESCRIPTION
I'm hoping this is correct -- trying to install [linguist](https://github.com/github/linguist) locally to check went deep into a macOS/Ruby hole where [charlock_holmes](https://github.com/brianmario/charlock_holmes) fails to compile due to C++17 and/or clang issues, at which point I decided I wasn't going to spend any more time on trying to test this locally.  :-/