### PR TITLE
introduce projfs_get_user_data() public API method

### DIFF
--- a/include/projfs.h
+++ b/include/projfs.h
@@ -100,6 +100,14 @@ struct projfs *projfs_new(const char *lowerdir, const char *mountdir,
 			  size_t handlers_size, void *user_data);
 
 /**
+ * Retrieve the private user data from a projfs handle.
+ *
+ * @param[in] fs Projected filesystem handle.
+ * @return The user_data reference as passed to \p projfs_new().
+ */
+void *projfs_get_user_data(struct projfs *fs);
+
+/**
  * Start a projfs filesystem.
  * TODO: doxygen
  */

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -1016,6 +1016,11 @@ out:
 	return NULL;
 }
 
+void *projfs_get_user_data(struct projfs *fs)
+{
+	return fs->user_data;
+}
+
 /**
  * @return 1 if dir is empty, 0 if not, -1 if an error occurred (errno set)
  */

--- a/lib/projfs_vfsapi.c
+++ b/lib/projfs_vfsapi.c
@@ -196,12 +196,13 @@ static int convert_result_to_errno(PrjFS_Result result)
 
 static int handle_proj_event(struct projfs_event *event)
 {
-	PrjFS_Callbacks *callbacks = (PrjFS_Callbacks *) event->fs->user_data;
+	PrjFS_Callbacks *callbacks;
 	PrjFS_Result result;
 	char *cmdline = NULL;
 	const char *triggeringProcessName = "";
 	int ret = 0;
 
+	callbacks = (PrjFS_Callbacks *) projfs_get_user_data(event->fs);
 	if (callbacks == NULL)
 		goto out;
 
@@ -244,7 +245,7 @@ out:
 
 static int handle_nonproj_event(struct projfs_event *event, int perm)
 {
-	PrjFS_Callbacks *callbacks = (PrjFS_Callbacks *) event->fs->user_data;
+	PrjFS_Callbacks *callbacks;
 	PrjFS_NotifyOperationCallback *callback;
 	PrjFS_NotificationType notificationType = PrjFS_NotificationType_None;
 	unsigned char providerId[PrjFS_PlaceholderIdLength];
@@ -255,6 +256,7 @@ static int handle_nonproj_event(struct projfs_event *event, int perm)
 	const char *triggeringProcessName = "";
 	int ret = 0;
 
+	callbacks = (PrjFS_Callbacks *) projfs_get_user_data(event->fs);
 	if (callbacks == NULL)
 		goto out;
 


### PR DESCRIPTION
Allow callers to retrieve their `user_data` via our public API, as the our `projfs` structure is opaque to them.