### PR TITLE
mark test exit_usage() as noreturn

### DIFF
--- a/t/test_common.c
+++ b/t/test_common.c
@@ -139,6 +139,7 @@ static const char *get_program_name(const char *program)
 	return program;
 }
 
+__attribute__((noreturn))
 static void exit_usage(int err, const char *argv0, struct option *long_opts,
 		       const char *args_usage)
 {


### PR DESCRIPTION
Fixes a compiler warning about case statement falling through in `test_parse_opts()`.