### PR TITLE
Add configure option to support custom libfuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 /libprojfs-*.tar.*z
 /ltmain.sh
 /m4/*
-!/m4/ax_*.m4
+!/m4/ax*.m4
 /missing
 /projfs.pc
 /t/.prove

--- a/autogen.sh
+++ b/autogen.sh
@@ -27,6 +27,5 @@ aclocal -Wall --install -I m4 &&
   libtoolize -Wall --copy &&
   autoheader -Wall &&
   autoconf -Wall &&
-  automake -Wall --add-missing --copy &&
-  ./configure "$@"
+  automake -Wall --add-missing --copy
 

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,12 @@ AS_IF([test ":$enable_vfs_api" = ":yes"],
 AM_CONDITIONAL([ENABLE_VFSAPI], [test ":$enable_vfs_api" = ":yes"])
 AC_SUBST([libprojfs_export_regex])
 
+AC_CHECK_PROGS([DIFF], [diff])
+AC_ARG_VAR([DIFF], [File comparison tool])
+
+AC_CHECK_PROGS([PROVE], [prove])
+AC_ARG_VAR([PROVE], [TAP harness command, e.g., 'prove -v'])
+
 pkgconfigdir='${libdir}/pkgconfig'
 
 AC_ARG_WITH([pkgconfigdir],
@@ -131,12 +137,6 @@ AC_SEARCH_LIBS([fuse_loop_mt_31], [fuse3], [],
 AC_SEARCH_LIBS([fuse_context_node_userdata_release], [fuse3], [],
   [AC_MSG_ERROR([FUSE library with per-node userdata support not found])]dnl
 )dnl
-
-AC_CHECK_PROGS([DIFF], [diff])
-AC_ARG_VAR([DIFF], [File comparison tool])
-
-AC_CHECK_PROGS([PROVE], [prove])
-AC_ARG_VAR([PROVE], [TAP harness command, e.g., 'prove -v'])
 
 AC_CONFIG_FILES([Makefile include/Makefile lib/Makefile t/Makefile
                  config.sh projfs.pc])

--- a/configure.ac
+++ b/configure.ac
@@ -76,8 +76,37 @@ AC_SUBST([libprojfs_export_regex])
 AC_CHECK_PROGS([DIFF], [diff])
 AC_ARG_VAR([DIFF], [File comparison tool])
 
+AC_CHECK_PROGS([PKGCONFIG], [pkg-config])
+AC_ARG_VAR([PKGCONFIG], [Package configuration tool])
+
 AC_CHECK_PROGS([PROVE], [prove])
 AC_ARG_VAR([PROVE], [TAP harness command, e.g., 'prove -v'])
+
+# TODO: remove explicit --with-libfusepkg when we no longer need a custom
+# libfuse, and/or when we no longer use FUSE at all
+AC_ARG_WITH([libfusepkg],
+  [AS_HELP_STRING([--with-libfusepkg=PCFILE],
+    [Use FUSE library with pkg-config .pc file PCFILE])]
+)dnl
+
+# NOTE: altering user-supplied CPPFLAGS and LDFLAGS is normally frowned upon,
+#       but we want to make using a custom libfuse installation easy
+AS_IF([test ":$with_libfusepkg" != ":no" &&
+       test ":$with_libfusepkg" != ":yes" &&
+       test ":$with_libfusepkg" != ":"],
+  [AC_MSG_NOTICE([querying pkg-config using $with_libfusepkg file])
+   fuse_includedir=$("$PKGCONFIG" "$with_libfusepkg" --variable=includedir) ||
+     AC_MSG_ERROR([Failed to get libfuse include path using $with_libfusepkg])
+   fuse_libdir=$("$PKGCONFIG" "$with_libfusepkg" --variable=libdir) ||
+     AC_MSG_ERROR([Failed to get libfuse library path using $with_libfusepkg])
+   fuse_cppflags="-I$fuse_includedir"
+   AXLOCAL_PREPEND_FLAG([$fuse_cppflags], [CPPFLAGS])dnl
+   fuse_ldflags="-Wl,-R$fuse_libdir"
+   AXLOCAL_PREPEND_FLAG([$fuse_ldflags], [LDFLAGS])dnl
+   fuse_ldflags="-L$fuse_libdir"
+   AXLOCAL_PREPEND_FLAG([$fuse_ldflags], [LDFLAGS])dnl
+  ]dnl
+)dnl
 
 pkgconfigdir='${libdir}/pkgconfig'
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,8 @@
 
 AC_INIT([libprojfs], [0.1])
 
-AC_PREREQ([2.59])
+# highest version required by local m4 macros
+AC_PREREQ([2.64])
 AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-xz subdir-objects])
 LT_INIT
 

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,9 @@ AC_TYPE_UINT16_T
 AC_CHECK_HEADER([pthread.h], [],
   [AC_MSG_ERROR([POSIX threads header file not found])]dnl
 )dnl
+AC_SEARCH_LIBS([pthread_create], [pthread], [],
+  [AC_MSG_ERROR([POSIX threads library not found])]dnl
+)dnl
 
 AC_CHECK_HEADER([sys/fanotify.h], [],
   [AC_MSG_ERROR([Linux fanotify header file not found])]dnl
@@ -107,12 +110,21 @@ AC_CHECK_HEADER([sys/inotify.h], [],
   [AC_MSG_ERROR([Linux inotify header file not found])]dnl
 )dnl
 
-# TODO: remove when FUSE no longer used (also Libs.private in projfs.pc)
-AC_SEARCH_LIBS([fuse_new_30], [fuse3], [],
-  [AC_MSG_ERROR([FUSE version 3.x library not found])]dnl
+AC_CHECK_HEADER([attr/xattr.h], [],
+  [AC_MSG_ERROR([Extended attributes header file not found])]dnl
 )dnl
-AC_SEARCH_LIBS([pthread_create], [pthread], [],
-  [AC_MSG_ERROR([POSIX threads library not found])]dnl
+AC_SEARCH_LIBS([fsetxattr], [attr], [],
+  [AC_MSG_ERROR([Extended attributes library not found])]dnl
+)dnl
+
+# TODO: remove when FUSE no longer used (also Libs.private in projfs.pc)
+AC_CHECK_HEADER([fuse3/fuse.h], [],
+  [AC_MSG_ERROR([FUSE version 3.2+ header file not found])],
+  [@%:@define FUSE_USE_VERSION 32]dnl
+)dnl
+# NOTE: checking for fuse_loop_mt_31() ensures libfuse version 3.2 or higher
+AC_SEARCH_LIBS([fuse_loop_mt_31], [fuse3], [],
+  [AC_MSG_ERROR([FUSE version 3.2+ library not found])]dnl
 )dnl
 
 AC_CHECK_PROGS([DIFF], [diff])

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,10 @@ AC_CHECK_HEADER([fuse3/fuse.h], [],
 AC_SEARCH_LIBS([fuse_loop_mt_31], [fuse3], [],
   [AC_MSG_ERROR([FUSE version 3.2+ library not found])]dnl
 )dnl
+# TODO: remove when custom FUSE no longer used
+AC_SEARCH_LIBS([fuse_context_node_userdata_release], [fuse3], [],
+  [AC_MSG_ERROR([FUSE library with per-node userdata support not found])]dnl
+)dnl
 
 AC_CHECK_PROGS([DIFF], [diff])
 AC_ARG_VAR([DIFF], [File comparison tool])

--- a/docs/build-install.md
+++ b/docs/build-install.md
@@ -161,15 +161,31 @@ $ ./configure --enable-vfs-api && make && make test
 
 Note that unless you installed your modified libfuse library into a system
 location, you will need to ensure that the `configure` script finds your
-libfuse installation by setting the `CPPFLAGS` and `LDFLAGS` environment
-variables appropriately.  For example (but check first that the paths you
-supply actually contain `fuse3/fuse.h` for the `-I` option and `libfuse3.so`
-for the `-L` and `-Wl,-R` options; you may need to append additional path
-segments such as `x86_64-linux-gnu` or similar subdirectories):
+libfuse installation by either setting the `CPPFLAGS` and `LDFLAGS`
+environment variables, or by providing the path to the `fuse3.pc` package
+configuration metadata file with the `--with-libfusepkg` option.
+
+For example, if you installed your modified libfuse library into
+`/path/to/libfuse` and you have a `fuse3.pc` metadata file under
+`lib64/pkgconfig/fuse3.pc`, you can use the `--with-libfusepkg` option
+as follows (and note that this example also enables the VFSForGit API):
+```
+  ./configure --with-libfusepkg=/path/to/libfuse/lib64/pkgconfig/fuse3.pc \
+              --enable-vfs-api && \
+  make && \
+  make test
+```
+
+If you are unable to use the `--with-libfusepkg` option for some
+reason, you can instead supply the `CPPFLAGS` and `LDFLAGS` environment
+variables to `configure`, but first ensure that the paths you use
+actually contain `fuse3/fuse.h` for the `-I` option and `libfuse3.so`
+for the `-L` and `-Wl,-R` options.  (You may need to append additional
+path segments such as `x86_64-linux-gnu` or similar subdirectories.)
 ```
 $ CPPFLAGS=-I/path/to/libfuse/include \
     LDFLAGS='-L/path/to/libfuse/lib -Wl,-R/path/to/libfuse/lib' \
-    ./configure && \
+    ./configure --enable-vfs-api && \
   make && \
   make test
 ```

--- a/docs/build-install.md
+++ b/docs/build-install.md
@@ -134,9 +134,7 @@ $ git clone https://github.com/github/libprojfs.git
 source code using the "Clone or download" button on this page.)
 
 Next, run the `autogen.sh` script to generate an [Autoconf][autoconf]
-`configure` script.  (If you don't have your modified libfuse in a
-system location, you may need to supply `CPPFLAGS` and `LDFLAGS`
-to `autogen.sh` too; see the next paragraph for an example.)
+`configure` script:
 ```
 $ ./autogen.sh
 ```

--- a/m4/axlocal_prepend_flag.m4
+++ b/m4/axlocal_prepend_flag.m4
@@ -1,0 +1,48 @@
+# SYNOPSIS
+#
+#   AXLOCAL_PREPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is prepended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_APPEND_FLAG by
+#         Guido U. Draheim <guidod@gmx.de> and
+#         Maarten Bosmans <mkbosmans@gmail.com>
+#
+# LICENSE
+#
+#   Copyright (C) 2019 GitHub, Inc.
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AXLOCAL_PREPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_COPY(tmp_flags,FLAGS)
+     AS_VAR_SET(FLAGS,["$1 $tmp_flags"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AXLOCAL_PREPEND_FLAG


### PR DESCRIPTION
The primary addition in this patchset is the `--with-libfusepkg=...` option to the `configure` script, which permits someone to avoid fiddling too much with both `CPPFLAGS` and `LDFLAGS`, e.g.:
```
./autogen.sh && \
./configure --with-libfusepkg=/path/to/libfuse/lib/pkgconfig/fuse3.pc
```

We also add configuration-time checks for to ensure we're compiling against a libfuse version 3.2+ that has our custom modifications (i.e., `fuse_context_node_userdata_*()`, and that we have extended attribute support as well from the system libraries.

Finally we simplify `autogen.sh` by skipping the unnecessary and now-complicated `./configure` final step, which would now usually fail since it goes looking for a special libfuse and the user hasn't supplied extra parameters to `autogen.sh`.