### PR TITLE
enhance CI suite logging, mount path configs, and cleanup

### DIFF
--- a/docker/cibuild
+++ b/docker/cibuild
@@ -12,6 +12,7 @@ cd "$(dirname "$0")"
 ./projfs develop make
 ./projfs develop test || (
 	cat ../t/test-suite.log;
+	tail -n +1 ../t/test-output/*;
 	exit 1
 )
 

--- a/docker/projfs
+++ b/docker/projfs
@@ -109,7 +109,7 @@ end
 # may be bind-mounted on an external filesystem which lacks xattr support.
 
 def test_options
-  opts = ['--root=/tmp']
+  opts = ['--root=/tmp', '--verbose-log', '-x']
   ["PROJFS_TEST_OPTS=#{opts.join ' '}"]
 end
 

--- a/docker/projfs
+++ b/docker/projfs
@@ -84,17 +84,15 @@ def escape_shellarg(str)
   Shellwords.shellescape(str).gsub('\=', '=')
 end
 
-class Array
-  def to_shellstr
-    self.map { |s| escape_shellarg(s) }.join ' '
-  end
+def to_shellstr(a)
+  a.map { |s| escape_shellarg(s) }.join ' '
 end
 
 def system(*args)
-  puts ">> #{args.to_shellstr}"
+  puts ">> #{to_shellstr(args)}"
   result = Kernel.system(*args)
   if !result
-    raise "failed to run '#{args.to_shellstr}"
+    raise "failed to run '#{to_shellstr(args)}"
   end
 end
 

--- a/docker/projfs
+++ b/docker/projfs
@@ -21,6 +21,8 @@
 # License along with this library, in the file COPYING; if not,
 # see <http://www.gnu.org/licenses/>.
 
+require 'shellwords'
+
 require_relative 'project'
 require_relative 'tests'
 
@@ -78,11 +80,21 @@ def usage
   exit 1
 end
 
+def escape_shellarg(str)
+  Shellwords.shellescape(str).gsub('\=', '=')
+end
+
+class Array
+  def to_shellstr
+    self.map { |s| escape_shellarg(s) }.join ' '
+  end
+end
+
 def system(*args)
-  puts ">> #{args.join " "}"
+  puts ">> #{args.to_shellstr}"
   result = Kernel.system(*args)
   if !result
-    raise "failed to run '#{args.join " "}"
+    raise "failed to run '#{args.to_shellstr}"
   end
 end
 

--- a/docker/projfs
+++ b/docker/projfs
@@ -98,6 +98,21 @@ def system(*args)
   end
 end
 
+# We assume /tmp is a regular directory in the container's root filesystem,
+# and that the writable upper layer of that union filesystem is stored
+# on a host filesytem which supports "user.*" extended attributes, like ext4.
+#
+# Note that a Docker option like "--tmpfs /tmp" may break this assumption,
+# as tmpfs does not support user extended attributes.
+#
+# We avoid using our /data/* build directories for testing because they
+# may be bind-mounted on an external filesystem which lacks xattr support.
+
+def test_options
+  opts = ['--root=/tmp']
+  ["PROJFS_TEST_OPTS=#{opts.join ' '}"]
+end
+
 usage if ARGV.length == 0
 
 fuse3 = Project.new('fuse3',
@@ -113,9 +128,9 @@ develop = Project.new('develop',
     autogen: ['./autogen.sh'],
     configure: ['./configure', '--enable-vfs-api'],
     make: ['make'],
-    test: ['make', 'test'],
+    test: [['env', *test_options, 'make', 'test']],
     dist: ['make', 'dist'],
-    clean: ['make', 'clean'],
+    clean: [['env', *test_options, 'make', 'clean']],
   },
   build_options: ['--build-arg', "UID=#{Process.uid}"],
   options: ['--device', '/dev/fuse', '--cap-add', 'SYS_ADMIN', '--security-opt', 'apparmor:unconfined'])

--- a/docker/projfs
+++ b/docker/projfs
@@ -113,6 +113,13 @@ def test_options
   ["PROJFS_TEST_OPTS=#{opts.join ' '}"]
 end
 
+def dotnet_env
+  vars = ["DOTNET_CLI_TELEMETRY_OPTOUT=1",
+          "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1",
+          "NUGET_XMLDOC_MODE=skip"]
+  ["env", *vars]
+end
+
 usage if ARGV.length == 0
 
 fuse3 = Project.new('fuse3',
@@ -151,12 +158,12 @@ vfs = Project.new('vfs',
   ],
   commands: {
     restore: [
-      ["dotnet", "restore", "MirrorProvider/MirrorProvider.sln", "/p:Configuration=Debug.Linux", "--packages", "../packages"],
-      ["dotnet", "restore", "ProjFS.Linux/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj", "/p:Configuration=Debug", "/p:Platform=x64", "--packages", "../packages"],
+      [*dotnet_env, "dotnet", "restore", "MirrorProvider/MirrorProvider.sln", "/p:Configuration=Debug.Linux", "--packages", "../packages"],
+      [*dotnet_env, "dotnet", "restore", "ProjFS.Linux/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj", "/p:Configuration=Debug", "/p:Platform=x64", "--packages", "../packages"],
     ],
     make: [
-      ["dotnet", "build", "ProjFS.Linux/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj", "/p:Configuration=Debug", "/p:Platform=x64", "--no-restore"],
-      ["dotnet", "build", "MirrorProvider/MirrorProvider.sln", "/p:Configuration=Debug.Linux", "--no-restore"],
+      [*dotnet_env, "dotnet", "build", "ProjFS.Linux/PrjFSLib.Linux.Managed/PrjFSLib.Linux.Managed.csproj", "/p:Configuration=Debug", "/p:Platform=x64", "--no-restore"],
+      [*dotnet_env, "dotnet", "build", "MirrorProvider/MirrorProvider.sln", "/p:Configuration=Debug.Linux", "--no-restore"],
     ]
   })
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -71,14 +71,12 @@ else !ENABLE_VFSAPI
 SKIP_TESTS = t[5-9]??
 endif !ENABLE_VFSAPI
 
-EXTRA_DIST = README.md chainlint.sed \
+EXTRA_DIST = README.md chainlint.sed clean_test_dirs.sh \
 	     test-lib.sh test-lib-event.sh test-lib-functions.sh $(TESTS)
 
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' HARNESS_ACTIVE=true \
 	$(SHELL) ../tap-driver.sh
 
-TEST_MOUNTS_DIR = test-mounts
-TEST_OUTPUT_DIR = test-output
 PROVE_FILE = .prove
 
 check-local: clean-mounts
@@ -87,7 +85,7 @@ check-local: clean-mounts
 test: check
 
 .PHONY: prove
-prove: clean-mounts clean-output $(check_PROGRAMS)
+prove: clean-mounts $(check_PROGRAMS)
 	@if test ":$(PROVE)" != ":"; \
 	then \
 		prove_dir="."; \
@@ -100,19 +98,19 @@ prove: clean-mounts clean-output $(check_PROGRAMS)
 		PROJFS_SKIP_TESTS="$(SKIP_TESTS) $$PROJFS_SKIP_TESTS" \
 			$(PROVE) --exec $(SHELL) \
 				$(PROJFS_PROVE_OPTS) $$prove_dir; \
-		$(RM) -r "$(TEST_MOUNTS_DIR)" "/tmp/$(TEST_MOUNTS_DIR)"; \
+		./clean_test_dirs.sh; \
 	else \
 		echo "No 'prove' TAP harness available." && exit 1; \
 	fi
 
 clean-mounts:
-	@$(RM) -r "$(TEST_MOUNTS_DIR)" "/tmp/$(TEST_MOUNTS_DIR)"
+	@./clean_test_dirs.sh
 
-clean-output:
-	@$(RM) -r "$(TEST_OUTPUT_DIR)"
+clean-mounts-output:
+	@./clean_test_dirs.sh --all
 
 clean-prove:
 	@$(RM) $(PROVE_FILE)
 
-clean-local: clean-mounts clean-output clean-prove
+clean-local: clean-mounts-output clean-prove
 

--- a/t/clean_test_dirs.sh
+++ b/t/clean_test_dirs.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Copyright (C) 2018-2019 GitHub, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/ .
+
+test_description='test directory cleanup utility'
+
+if test $# -eq 1 && test ":$1" = ":--all"
+then
+	set -- --clean-all
+elif test $# -ne 0
+then
+	>&2 echo "Usage: $0 [--all]"
+	exit 1
+else
+	set -- --clean
+fi
+
+. ./test-lib.sh
+

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -850,10 +850,6 @@ fi
 
 # Test mount points
 TRASH_DIRECTORY="test-mounts/$(basename "$0" .t)"
-if test -f /.dockerenv
-then
-	TRASH_DIRECTORY="/tmp/$TRASH_DIRECTORY"
-fi
 test -n "$root" && TRASH_DIRECTORY="$root/$TRASH_DIRECTORY"
 case "$TRASH_DIRECTORY" in
 /*) ;; # absolute path is good


### PR DESCRIPTION
After a lot of bashing (pun intended, sigh), I think this set of changes is relatively solid now, modulo any non-idiomatic Ruby I've used, or bugs I've introduced, of course.

The primary goal here was to tune up the CI suite so it could use the handy options provided by the test suite, like `-V -x` and `--root`.  Getting the latter option to work then suggested also revising the test suite's `Makefile` so that it didn't assume the test mount location was under `t/` but instead found the correct one using the same logic as the tests themselves.

There are some associated changes to the log output from `system()` in `docker/projfs` so the `PROJFS_TEST_OPTS=--root=tmp --verbose-log -x` argument doesn't appear like three separate args in the CI output, and finally some tweaks to the `dotnet` commands so they don't output any "Hello, welcome to .NET Core!" messages or do telemetry.

(P.S.  The log and code comments about `/tmp` are more verbose than necessary, but I wanted to capture the details of the differences between "client/external" bind-mounted OS, like APFS on Mac, Docker Linux host ext4 OS (possibly running inside a hypervisor as found in Docker for Mac), and Docker container OS (overlayfs), both for posterity and for my own edification when I forget in the future!  :-)
