### PR TITLE
revise and refine test lib common vars and error exits

### DIFF
--- a/t/test_common.c
+++ b/t/test_common.c
@@ -446,13 +446,11 @@ void test_wait_signal(void)
 {
 	int tty = isatty(STDIN_FILENO);
 
-	if (tty < 0)
-		warn("unable to check stdin");
-	else if (tty) {
+	if (tty == 1) {
 		printf("hit Enter to stop: ");
 		getchar();
 	}
-	else {
+	else if (errno == EINVAL || errno == ENOTTY) {
 		struct sigaction sa;
 
 		memset(&sa, 0, sizeof(struct sigaction));
@@ -466,5 +464,7 @@ void test_wait_signal(void)
 		else
 			pause();
 	}
+	else
+		warn("unable to check stdin");
 }
 

--- a/t/test_common.c
+++ b/t/test_common.c
@@ -119,8 +119,8 @@ static const struct opt_usage all_opts_usage[] = {
 };
 
 /* option values */
-static int retval;
-static long int timeout;
+static int optval_retval;
+static long int optval_timeout;
 
 static unsigned int opt_set_flags = TEST_OPT_NONE;
 
@@ -288,7 +288,8 @@ void test_parse_opts(int argc, char *const argv[], unsigned int opt_flags,
 			exit_usage(0, argv[0], long_opts, args_usage);
 
 		case TEST_OPT_NUM_RETVAL:
-			if (test_parse_retsym(vfsapi, optarg, &retval) < 0)
+			if (test_parse_retsym(vfsapi, optarg,
+					      &optval_retval) < 0)
 				test_exit_error(argv[0], "invalid retval: %s",
 						optarg);
 			else
@@ -296,8 +297,8 @@ void test_parse_opts(int argc, char *const argv[], unsigned int opt_flags,
 			break;
 
 		case TEST_OPT_NUM_TIMEOUT:
-			timeout = test_parse_long(optarg, 10);
-			if (errno > 0 || timeout < 0)
+			optval_timeout = test_parse_long(optarg, 10);
+			if (errno > 0 || optval_timeout < 0)
 				test_exit_error(argv[0],
 						"invalid timeout: %s",
 						optarg);
@@ -370,13 +371,13 @@ unsigned int test_get_opts(unsigned int opt_flags, ...)
 			case TEST_OPT_RETVAL:
 				i = va_arg(ap, int*);
 				if (ret_flag != TEST_OPT_NONE)
-					*i = retval;
+					*i = optval_retval;
 				break;
 
 			case TEST_OPT_TIMEOUT:
 				l = va_arg(ap, long int*);
 				if (ret_flag != TEST_OPT_NONE)
-					*l = timeout;
+					*l = optval_timeout;
 				break;
 
 			default:

--- a/t/test_common.c
+++ b/t/test_common.c
@@ -298,14 +298,16 @@ void test_parse_opts(int argc, char *const argv[], unsigned int opt_flags,
 		case TEST_OPT_NUM_TIMEOUT:
 			timeout = test_parse_long(optarg, 10);
 			if (errno > 0 || timeout < 0)
-				test_exit_error(argv[0], "invalid timeout: %s",
+				test_exit_error(argv[0],
+						"invalid timeout: %s",
 						optarg);
 			opt_set_flags |= TEST_OPT_TIMEOUT;
 			break;
 
 		case '?':
 			if (optopt > 0)
-				test_exit_error(argv[0], "invalid option: -%c",
+				test_exit_error(argv[0],
+						"invalid option: -%c",
 						optopt);
 			else
 				test_exit_error(argv[0], "invalid option: %s",
@@ -378,8 +380,8 @@ unsigned int test_get_opts(unsigned int opt_flags, ...)
 				break;
 
 			default:
-				err(EXIT_FAILURE,
-				    "unknown option flag: %u", opt_flag);
+				errx(EXIT_FAILURE,
+				     "unknown option flag: %u", opt_flag);
 		}
 	}
 
@@ -398,10 +400,10 @@ struct projfs *test_start_mount(const char *lowerdir, const char *mountdir,
 			user_data);
 
 	if (fs == NULL)
-		err(EXIT_FAILURE, "unable to create filesystem");
+		errx(EXIT_FAILURE, "unable to create filesystem");
 
 	if (projfs_start(fs) < 0)
-		err(EXIT_FAILURE, "unable to start filesystem");
+		errx(EXIT_FAILURE, "unable to start filesystem");
 
 	return fs;
 }
@@ -426,7 +428,7 @@ void test_start_vfsapi_mount(const char *storageRootFullPath,
 						mountHandle);
 
 	if (ret != PrjFS_Result_Success)
-		err(EXIT_FAILURE, "unable to start filesystem: %d", ret);
+		errx(EXIT_FAILURE, "unable to start filesystem: %d", ret);
 }
 
 void test_stop_vfsapi_mount(PrjFS_MountHandle* mountHandle)

--- a/t/wait_mount.c
+++ b/t/wait_mount.c
@@ -66,7 +66,8 @@ static int wait_for_mount(dev_t prior_dev, const char *mountdir,
 		if (stat(mountdir, &mnt) != 0) {
 			// limit warnings to once per second
 			if (warn_sec < wait) {
-				warn("unable to check mount point");
+				warn("unable to query mount point: %s",
+				     mountdir);
 				warn_sec = wait;
 			}
 		} else if (prior_dev != mnt.st_dev)
@@ -80,7 +81,8 @@ static int wait_for_mount(dev_t prior_dev, const char *mountdir,
 
 		wait = now - start;
 		if (wait >= max_wait) {
-			warnx("timeout waiting for filesystem mount");
+			warnx("timeout waiting for filesystem mount at: %s",
+			      mountdir);
 			ret = -1;
 			break;
 		}


### PR DESCRIPTION
This is a bit of prep cleanup I've pulled out of the larger projection test work, which is done (well, done to the point that I believe all the tests work again after adding projection handlers to the test suite) and will be the next PR after this one (I think!  :-)