### PR TITLE
add projection test handlers to test suite

### DIFF
--- a/t/t200-event-ok.t
+++ b/t/t200-event-ok.t
@@ -24,7 +24,8 @@ events are received and handled correctly.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_projfs_handlers source target || exit 1
+projfs_start test_projfs_handlers source target --retval-file retval || exit 1
+touch retval
 
 projfs_event_printf notify create_dir d1
 test_expect_success 'test event handler on parent directory creation' '
@@ -76,6 +77,7 @@ test_expect_success 'test permission granted on parent directory deletion' '
 	test_path_is_missing target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t201-event-err.t
+++ b/t/t201-event-err.t
@@ -24,7 +24,8 @@ events respond to handler errors.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_projfs_handlers source target --retval ENOMEM || exit 1
+projfs_start test_projfs_handlers source target --retval-file retval || exit 1
+echo ENOMEM > retval
 
 # TODO: we expect mkdir to create a dir despite the handler error and
 #	regardless of mkdir's failure exit code
@@ -54,6 +55,7 @@ test_expect_success 'test event handler error on directory deletion' '
 	test_path_is_dir target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t202-event-deny.t
+++ b/t/t202-event-deny.t
@@ -24,7 +24,8 @@ denial responses from event handlers.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_projfs_handlers source target --retval deny || exit 1
+projfs_start test_projfs_handlers source target --retval-file retval || exit 1
+echo deny > retval
 
 projfs_event_printf notify create_dir d1
 test_expect_success 'test event handler on directory creation' '
@@ -50,6 +51,7 @@ test_expect_success 'test permission request denied on directory deletion' '
 	test_path_is_dir target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t203-event-null.t
+++ b/t/t203-event-null.t
@@ -24,7 +24,8 @@ denial responses caused by event handlers returning null.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_projfs_handlers source target --retval null || exit 1
+projfs_start test_projfs_handlers source target --retval-file retval || exit 1
+echo null > retval
 
 projfs_event_printf notify create_dir d1
 test_expect_success 'test event handler on directory creation' '
@@ -50,6 +51,7 @@ test_expect_success 'test permission request denied on directory deletion' '
 	test_path_is_dir target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t204-event-allow.t
+++ b/t/t204-event-allow.t
@@ -24,7 +24,8 @@ explicit allowed responses from event handlers.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_projfs_handlers source target --retval allow || exit 1
+projfs_start test_projfs_handlers source target --retval-file retval || exit 1
+echo allow > retval
 
 projfs_event_printf notify create_dir d1
 test_expect_success 'test event handler on directory creation' '
@@ -50,6 +51,7 @@ test_expect_success 'test permission request allowed on directory deletion' '
 	test_path_is_missing target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t700-vfs-event-ok.t
+++ b/t/t700-vfs-event-ok.t
@@ -24,7 +24,8 @@ events are received and handled correctly through the VFS API.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_vfsapi_handlers source target || exit 1
+projfs_start test_vfsapi_handlers source target --retval-file retval || exit 1
+touch retval
 
 projfs_event_printf vfs create_dir d1
 test_expect_success 'test event handler on parent directory creation' '
@@ -76,6 +77,7 @@ test_expect_success 'test permission granted on parent directory deletion' '
 	test_path_is_missing target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t701-vfs-event-err.t
+++ b/t/t701-vfs-event-err.t
@@ -24,7 +24,8 @@ events respond to handler errors through the VFS API.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_vfsapi_handlers source target --retval EOutOfMemory || exit 1
+projfs_start test_vfsapi_handlers source target --retval-file retval || exit 1
+echo EOutOfMemory > retval
 
 # TODO: we expect mkdir to create a dir despite the handler error and
 #	regardless of mkdir's failure exit code
@@ -54,6 +55,7 @@ test_expect_success 'test event handler error on directory deletion' '
 	test_path_is_dir target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t702-vfs-event-deny.t
+++ b/t/t702-vfs-event-deny.t
@@ -24,7 +24,8 @@ denial responses from event handlers through the VFS API.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_vfsapi_handlers source target --retval deny || exit 1
+projfs_start test_vfsapi_handlers source target --retval-file retval || exit 1
+echo deny > retval
 
 # TODO: test_vfsapi_handlers always returns EPERM with --retval deny, unlike
 #	test_projfs_handlers, so mkdir gets a handler error; like t701.1,
@@ -58,6 +59,7 @@ test_expect_success 'test permission request denied on directory deletion' '
 	test_path_is_dir target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t703-vfs-event-null.t
+++ b/t/t703-vfs-event-null.t
@@ -25,7 +25,8 @@ the VFS API.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_vfsapi_handlers source target --retval null || exit 1
+projfs_start test_vfsapi_handlers source target --retval-file retval || exit 1
+echo null > retval
 
 # TODO: test_vfsapi_handlers always returns EINVAL with --retval null, unlike
 #	test_projfs_handlers, so mkdir sees a handler error; like t701.1,
@@ -59,6 +60,7 @@ test_expect_success 'test permission request denied on directory deletion' '
 	test_path_is_dir target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/t704-vfs-event-allow.t
+++ b/t/t704-vfs-event-allow.t
@@ -24,7 +24,8 @@ explicit allowed responses from event handlers through the VFS API.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/test-lib-event.sh
 
-projfs_start test_vfsapi_handlers source target --retval allow || exit 1
+projfs_start test_vfsapi_handlers source target --retval-file retval || exit 1
+echo allow > retval
 
 projfs_event_printf vfs create_dir d1
 test_expect_success 'test event handler on directory creation' '
@@ -50,6 +51,7 @@ test_expect_success 'test permission request allowed on directory deletion' '
 	test_path_is_missing target/d1
 '
 
+rm retval
 projfs_stop || exit 1
 
 test_expect_success 'check all event notifications' '

--- a/t/test_common.h
+++ b/t/test_common.h
@@ -28,15 +28,23 @@
 
 #define TEST_OPT_NUM_HELP	0
 #define TEST_OPT_NUM_RETVAL	1
-// TODO: TEST_OPT_NUM_RETFILE
+#define TEST_OPT_NUM_RETFILE	2
 #define TEST_OPT_NUM_TIMEOUT	3
 
 #define TEST_OPT_HELP		(0x0001 << TEST_OPT_NUM_HELP)
 #define TEST_OPT_RETVAL		(0x0001 << TEST_OPT_NUM_RETVAL)
+#define TEST_OPT_RETFILE	(0x0001 << TEST_OPT_NUM_RETFILE)
 #define TEST_OPT_TIMEOUT	(0x0001 << TEST_OPT_NUM_TIMEOUT)
 
 #define TEST_OPT_NONE		0x0000
 #define TEST_OPT_VFSAPI		0x8000		// not a command-line option
+
+#define TEST_VAL_UNSET		0x0000
+#define TEST_VAL_SET		0x0001
+
+#define TEST_FILE_NONE		0x0000
+#define TEST_FILE_EXIST		0x0002
+#define TEST_FILE_VALID		0x0004
 
 void test_exit_error(const char *argv0, const char *fmt, ...);
 

--- a/t/test_projfs_handlers.c
+++ b/t/test_projfs_handlers.c
@@ -28,15 +28,21 @@
 static int test_handle_event(struct projfs_event *event, const char *desc,
 			     int perm)
 {
-	unsigned int ret_flags;
+	unsigned int opt_flags, ret_flags;
+	const char *retfile;
 	int ret;
 
-	printf("  test %s for %s: "
-	       "0x%04" PRIx64 "-%08" PRIx64 ", %d\n",
-	       desc, event->path,
-	       event->mask >> 32, event->mask & 0xFFFFFFFF, event->pid);
+	opt_flags = test_get_opts((TEST_OPT_RETVAL | TEST_OPT_RETFILE),
+				  &ret, &ret_flags, &retfile);
 
-	test_get_opts(TEST_OPT_RETVAL, &ret, &ret_flags);
+	if ((opt_flags & TEST_OPT_RETFILE) == TEST_OPT_NONE ||
+	    (ret_flags & TEST_FILE_EXIST) != TEST_FILE_NONE) {
+		printf("  test %s for %s: "
+		       "0x%04" PRIx64 "-%08" PRIx64 ", %d\n",
+		       desc, event->path,
+		       event->mask >> 32, event->mask & 0xFFFFFFFF,
+		       event->pid);
+	}
 
 	if ((ret_flags & TEST_VAL_SET) == TEST_VAL_UNSET)
 		ret = perm ? PROJFS_ALLOW : 0;
@@ -62,7 +68,8 @@ int main(int argc, char *const argv[])
 	struct projfs *fs;
 	struct projfs_handlers handlers = { 0 };
 
-	test_parse_mount_opts(argc, argv, TEST_OPT_RETVAL,
+	test_parse_mount_opts(argc, argv,
+			      (TEST_OPT_RETVAL | TEST_OPT_RETFILE),
 			      &lower_path, &mount_path);
 
 	handlers.handle_notify_event = &test_notify_event;

--- a/t/test_projfs_handlers.c
+++ b/t/test_projfs_handlers.c
@@ -28,7 +28,7 @@
 static int test_handle_event(struct projfs_event *event, const char *desc,
 			     int perm)
 {
-	unsigned int opt_flags;
+	unsigned int ret_flags;
 	int ret;
 
 	printf("  test %s for %s: "
@@ -36,9 +36,9 @@ static int test_handle_event(struct projfs_event *event, const char *desc,
 	       desc, event->path,
 	       event->mask >> 32, event->mask & 0xFFFFFFFF, event->pid);
 
-	opt_flags = test_get_opts(TEST_OPT_RETVAL, &ret);
+	test_get_opts(TEST_OPT_RETVAL, &ret, &ret_flags);
 
-	if (opt_flags == TEST_OPT_NONE)
+	if ((ret_flags & TEST_VAL_SET) == TEST_VAL_UNSET)
 		ret = perm ? PROJFS_ALLOW : 0;
 	else if(!perm && ret > 0)
 		ret = 0;

--- a/t/test_vfsapi_handlers.c
+++ b/t/test_vfsapi_handlers.c
@@ -39,19 +39,26 @@ static PrjFS_Result TestNotifyOperation(
     _In_    const char*                             destinationRelativePath
 )
 {
-	unsigned int ret_flags;
+	unsigned int opt_flags, ret_flags;
+	const char *retfile;
 	int ret;
 
-	printf("  TestNotifyOperation for %s: %d, %s, %hhd, 0x%08X\n",
-	       relativePath, triggeringProcessId, triggeringProcessName,
-	       isDirectory, notificationType);
+	opt_flags = test_get_opts((TEST_OPT_VFSAPI | TEST_OPT_RETVAL
+						   | TEST_OPT_RETFILE),
+				  &ret, &ret_flags, &retfile);
+
+	if ((opt_flags & TEST_OPT_RETFILE) == TEST_OPT_NONE ||
+	    (ret_flags & TEST_FILE_EXIST) != TEST_FILE_NONE) {
+		printf("  TestNotifyOperation for %s: %d, %s, %hhd, 0x%08X\n",
+		       relativePath,
+		       triggeringProcessId, triggeringProcessName,
+		       isDirectory, notificationType);
+	}
 
 	(void)commandId;		// prevent compiler warnings
 	(void)providerId;
 	(void)contentId;
 	(void)destinationRelativePath;
-
-	test_get_opts((TEST_OPT_VFSAPI | TEST_OPT_RETVAL), &ret, &ret_flags);
 
 	if ((ret_flags & TEST_VAL_SET) == TEST_VAL_UNSET)
 		ret = PrjFS_Result_Success;
@@ -65,7 +72,9 @@ int main(int argc, char *const argv[])
 	PrjFS_MountHandle *handle;
 	PrjFS_Callbacks callbacks = { 0 };
 
-	test_parse_mount_opts(argc, argv, (TEST_OPT_VFSAPI | TEST_OPT_RETVAL),
+	test_parse_mount_opts(argc, argv,
+			      (TEST_OPT_VFSAPI | TEST_OPT_RETVAL
+					       | TEST_OPT_RETFILE),
 			      &lower_path, &mount_path);
 
 	memset(&callbacks, 0, sizeof(PrjFS_Callbacks));

--- a/t/test_vfsapi_handlers.c
+++ b/t/test_vfsapi_handlers.c
@@ -39,8 +39,8 @@ static PrjFS_Result TestNotifyOperation(
     _In_    const char*                             destinationRelativePath
 )
 {
-	unsigned int opt_flags;
-	int retval;
+	unsigned int ret_flags;
+	int ret;
 
 	printf("  TestNotifyOperation for %s: %d, %s, %hhd, 0x%08X\n",
 	       relativePath, triggeringProcessId, triggeringProcessName,
@@ -51,10 +51,12 @@ static PrjFS_Result TestNotifyOperation(
 	(void)contentId;
 	(void)destinationRelativePath;
 
-	opt_flags = test_get_opts(TEST_OPT_RETVAL | TEST_OPT_VFSAPI, &retval);
+	test_get_opts((TEST_OPT_VFSAPI | TEST_OPT_RETVAL), &ret, &ret_flags);
 
-	return (opt_flags == TEST_OPT_NONE) ? PrjFS_Result_Success
-					    : retval;
+	if ((ret_flags & TEST_VAL_SET) == TEST_VAL_UNSET)
+		ret = PrjFS_Result_Success;
+
+	return ret;
 }
 
 int main(int argc, char *const argv[])

--- a/t/test_vfsapi_handlers.c
+++ b/t/test_vfsapi_handlers.c
@@ -27,6 +27,51 @@
 
 #include "test_common.h"
 
+static int test_handle_event(const char *desc, const char *path,
+			     int pid, const char *procname,
+			     int isdir, int type, int proj)
+{
+	unsigned int opt_flags, ret_flags;
+	const char *retfile;
+	int ret;
+
+	opt_flags = test_get_opts((TEST_OPT_VFSAPI | TEST_OPT_RETVAL
+						   | TEST_OPT_RETFILE),
+				  &ret, &ret_flags, &retfile);
+
+	if ((opt_flags & TEST_OPT_RETFILE) == TEST_OPT_NONE ||
+	    (ret_flags & TEST_FILE_EXIST) != TEST_FILE_NONE) {
+		printf("  Test%s for %s: %d, %s, %hhd, 0x%08X\n",
+		       desc, path, pid, procname, isdir, type);
+	}
+
+	if (proj) {
+		if (!isdir) {
+			fprintf(stderr, "unsupported file projection\n");
+			ret = PrjFS_Result_Invalid;
+		}
+	}
+
+	if ((ret_flags & TEST_VAL_SET) == TEST_VAL_UNSET)
+		ret = PrjFS_Result_Success;
+
+	return ret;
+}
+
+static PrjFS_Result TestEnumerateDirectory(
+    _In_    unsigned long                           commandId,
+    _In_    const char*                             relativePath,
+    _In_    int                                     triggeringProcessId,
+    _In_    const char*                             triggeringProcessName
+)
+{
+	(void)commandId;		// prevent compiler warnings
+
+	return test_handle_event("EnumerateDirectory", relativePath,
+				 triggeringProcessId, triggeringProcessName,
+				 1, 0, 1);
+}
+
 static PrjFS_Result TestNotifyOperation(
     _In_    unsigned long                           commandId,
     _In_    const char*                             relativePath,
@@ -39,31 +84,14 @@ static PrjFS_Result TestNotifyOperation(
     _In_    const char*                             destinationRelativePath
 )
 {
-	unsigned int opt_flags, ret_flags;
-	const char *retfile;
-	int ret;
-
-	opt_flags = test_get_opts((TEST_OPT_VFSAPI | TEST_OPT_RETVAL
-						   | TEST_OPT_RETFILE),
-				  &ret, &ret_flags, &retfile);
-
-	if ((opt_flags & TEST_OPT_RETFILE) == TEST_OPT_NONE ||
-	    (ret_flags & TEST_FILE_EXIST) != TEST_FILE_NONE) {
-		printf("  TestNotifyOperation for %s: %d, %s, %hhd, 0x%08X\n",
-		       relativePath,
-		       triggeringProcessId, triggeringProcessName,
-		       isDirectory, notificationType);
-	}
-
 	(void)commandId;		// prevent compiler warnings
 	(void)providerId;
 	(void)contentId;
 	(void)destinationRelativePath;
 
-	if ((ret_flags & TEST_VAL_SET) == TEST_VAL_UNSET)
-		ret = PrjFS_Result_Success;
-
-	return ret;
+	return test_handle_event("NotifyOperation", relativePath,
+				 triggeringProcessId, triggeringProcessName,
+				 isDirectory, notificationType, 0);
 }
 
 int main(int argc, char *const argv[])
@@ -78,6 +106,7 @@ int main(int argc, char *const argv[])
 			      &lower_path, &mount_path);
 
 	memset(&callbacks, 0, sizeof(PrjFS_Callbacks));
+	callbacks.EnumerateDirectory = TestEnumerateDirectory;
 	callbacks.NotifyOperation = TestNotifyOperation;
 
 	test_start_vfsapi_mount(lower_path, mount_path, callbacks,


### PR DESCRIPTION
This PR should address most of #7 as it is written, although more work is required to actually test direction projection, so that'll be a follow-up PR or two.

The primary changes here add the `--retval-file` option so that the simple new projection-callback logging added in 0775f50 only generates messages when they are expected by the test scripts.  Otherwise, background processes (like `gvfs-udisks2-volume-monitor` or even our `wait_mount` helper) cause initial log messages as they probe the new mount point which then throw off our tests.  We only want to start logging once things are up and running, after we know that -- at a minimum -- `wait_mount` (if not some other system daemon) has ensured that at least one program has triggered projection (really, hydration) of the top-level mount point directory.

We can also control the return values injected by the test handlers by placing values into the "control file" specified with `--retval-file`.  This isn't used much yet, but we could potentially combine many of the existing test scripts using this functionality.