### PR TITLE
remove unneeded virtualization root setup from VFS API

### DIFF
--- a/include/projfs_vfsapi.h
+++ b/include/projfs_vfsapi.h
@@ -107,9 +107,6 @@ typedef enum
     PrjFS_Result_EAccessDenied                      = 0x20000010,
     PrjFS_Result_EInvalidHandle                     = 0x20000020,
     PrjFS_Result_EIOError                           = 0x20000040,
-    // TODO: remove VirtualizationRoot error codes unless needed
-    PrjFS_Result_ENotAVirtualizationRoot            = 0x20000080,
-    PrjFS_Result_EVirtualizationRootAlreadyExists   = 0x20000100,
     PrjFS_Result_EDirectoryNotEmpty                 = 0x20000200,
     PrjFS_Result_EVirtualizationInvalidOperation    = 0x20000400,
 
@@ -150,10 +147,6 @@ PrjFS_Result PrjFS_StartVirtualizationInstance(
 
 void PrjFS_StopVirtualizationInstance(
     _In_    const PrjFS_MountHandle*                mountHandle
-);
-
-PrjFS_Result PrjFS_ConvertDirectoryToVirtualizationRoot(
-    _In_    const char*                             virtualizationRootFullPath
 );
 
 PrjFS_Result PrjFS_WritePlaceholderDirectory(

--- a/lib/projfs_vfsapi.c
+++ b/lib/projfs_vfsapi.c
@@ -187,9 +187,7 @@ static int convert_result_to_errno(PrjFS_Result result)
 		break;
 
 	case PrjFS_Result_Invalid:
-	case PrjFS_Result_ENotAVirtualizationRoot:
 	case PrjFS_Result_EVirtualizationInvalidOperation:
-	case PrjFS_Result_EVirtualizationRootAlreadyExists:
 	default:
 		ret = EINVAL;	// should imply an internal error, not client's
 	}
@@ -371,19 +369,6 @@ void PrjFS_StopVirtualizationInstance(
 
 	user_data = projfs_stop(fs);
 	free(user_data);
-}
-
-// TODO: likely unneeded; remove from VFS API and LinuxFileSystemVirtualizer
-//       - OR -
-//       use as a place to check for pre-existing mounts and clean them up
-PrjFS_Result PrjFS_ConvertDirectoryToVirtualizationRoot(
-    _In_    const char*                             virtualizationRootFullPath
-)
-{
-	// TODO: remove from function signature if not used
-	(void) virtualizationRootFullPath;
-
-	return PrjFS_Result_Success;
 }
 
 PrjFS_Result PrjFS_WritePlaceholderDirectory(

--- a/lib/projfs_vfsapi.c
+++ b/lib/projfs_vfsapi.c
@@ -153,6 +153,7 @@ static int convert_result_to_errno(PrjFS_Result result)
 		ret = EINVAL;
 		break;
 	case PrjFS_Result_EInvalidOperation:
+	case PrjFS_Result_EVirtualizationInvalidOperation:
 		ret = EPERM;
 		break;
 	case PrjFS_Result_ENotSupported:
@@ -187,7 +188,6 @@ static int convert_result_to_errno(PrjFS_Result result)
 		break;
 
 	case PrjFS_Result_Invalid:
-	case PrjFS_Result_EVirtualizationInvalidOperation:
 	default:
 		ret = EINVAL;	// should imply an internal error, not client's
 	}


### PR DESCRIPTION
We expect any Linux implementation to virtualize using a dedicated mounted filesystem, so we do not need to flag directories within the global file hierarchy as being virtualized. Therefore we can remove the `ConvertDirectoryToVirtualizationRoot()` function from the VFS API, as this was a legacy from copying the macOS implementation in order to get started on Linux development.

We can also remove the pair of associated error code which pertain to the setup of a virtualization root.

This requires a change to the `docker/VFSForGit` submodule's commit so we continue to build properly; see also the PR Microsoft/VFSForGit#788.