### PR TITLE
check lower fs for xattr and sparse file support

### DIFF
--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -1170,11 +1170,8 @@ static int test_sparse_support(int lowerdir_fd)
 	struct stat attrs;
 	int fd, res;
 
-	fd = openat(
-		lowerdir_fd,
-		SPARSE_TEST_FILENAME,
-		O_CREAT | O_TRUNC | O_RDWR,
-		0600);
+	fd = openat(lowerdir_fd, SPARSE_TEST_FILENAME,
+		    (O_CREAT | O_TRUNC | O_RDWR), 0600);
 	if (fd == -1)
 		return -1;
 


### PR DESCRIPTION
Lacking xattr support is a hard fail; lacking sparse file support is OK, but worth a warning.

Fixes #42.