### PR TITLE
add vfs test callback for file hydration

### DIFF
--- a/t/test_projfs_handlers.c
+++ b/t/test_projfs_handlers.c
@@ -53,6 +53,8 @@ static int test_handle_event(struct projfs_event *event, const char *desc,
 			fprintf(stderr, "unknown projection flags\n");
 			ret = -EINVAL;
 		}
+
+		// TODO: hydrate file/dir based on projection list
 	}
 
 	if ((ret_flags & TEST_VAL_SET) == TEST_VAL_UNSET)


### PR DESCRIPTION
This small change just tees us up for forthcoming work [see the projection-test-lists-wip branch :-)](https://github.com/github/libprojfs/tree/projection-test-lists-wip) to hydrate files and directories in the test suite through the VFS API.

No actual testing yet, though -- just a bit of plumbing.  Stay tuned!  :-/