### PR TITLE
allow arbitrary permission modes on projected dirs

### DIFF
--- a/include/projfs.h
+++ b/include/projfs.h
@@ -124,9 +124,10 @@ void *projfs_stop(struct projfs *fs);
  *
  * @param[in] fs Projected filesystem handle.
  * @param[in] path Relative path of new directory under projfs mount point.
+ * @param[in] mode File mode with which to create the new projected directory.
  * @return Zero on success or an \p errno(3) code on failure.
  */
-int projfs_create_proj_dir(struct projfs *fs, const char *path);
+int projfs_create_proj_dir(struct projfs *fs, const char *path, mode_t mode);
 
 /**
  * Create a file whose contents will be projected until written.

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -41,7 +41,6 @@
 #include <fuse3/fuse.h>
 
 #define lowerdir_fd() (projfs_context_fs()->lowerdir_fd)
-#define PROJ_DIR_MODE 0777
 
 // TODO: make this value configurable
 #define PROJ_WAIT_MSEC 5000
@@ -1445,7 +1444,7 @@ static int check_safe_rel_path(const char *path)
 	return 1;
 }
 
-int projfs_create_proj_dir(struct projfs *fs, const char *path)
+int projfs_create_proj_dir(struct projfs *fs, const char *path, mode_t mode)
 {
 	int fd;
 	char v = 1;
@@ -1454,7 +1453,7 @@ int projfs_create_proj_dir(struct projfs *fs, const char *path)
 	if (!check_safe_rel_path(path))
 		return EINVAL;
 
-	res = mkdirat(fs->lowerdir_fd, path, PROJ_DIR_MODE);
+	res = mkdirat(fs->lowerdir_fd, path, mode);
 	if (res == -1)
 		return errno;
 


### PR DESCRIPTION
As there is no compelling reason not to allow libprojfs callers to specify the permission mode bits of a projected directory, we can support this in our API, and defer to our callers (VFSForGit in particular) to supply the directory permissions they expect or require.

Note that this requires a change in the VFSForGit `ProjFS.Linux` code as well.