### PR TITLE
remove generic file IO write loop function

### DIFF
--- a/include/projfs.h
+++ b/include/projfs.h
@@ -153,8 +153,6 @@ int projfs_create_proj_file(struct projfs *fs, const char *path, off_t size,
 int projfs_create_proj_symlink(struct projfs *fs, const char *path,
 			       const char *target);
 
-int projfs_write_file_contents(int fd, const void *bytes, unsigned int count);
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -1512,16 +1512,3 @@ int projfs_create_proj_symlink(struct projfs *fs, const char *path,
 
 	return 0;
 }
-
-int projfs_write_file_contents(int fd, const void *bytes, unsigned int count)
-{
-	while (count) {
-		ssize_t res = write(fd, bytes, count);
-		if (res == -1)
-			return errno;
-		bytes = (char *)bytes + res;
-		count -= res;
-	}
-
-	return 0;
-}


### PR DESCRIPTION
We can defer to our callers the implementation details of how they want to write to the open file descriptor we provide as part of a file projection event.

In particular, the VFSForGit provider can perform this within its `WriteFileContents()` method in the `ProjFS.Linux` C# classes which interact with this library; see github/VFSForGit#6 for the corresponding changes.