### PR TITLE
use fs->lowerdir_fd when not in FUSE callback

### DIFF
--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -1574,7 +1574,7 @@ int projfs_create_proj_dir(struct projfs *fs, const char *path, mode_t mode,
 	if (mkdirat(fs->lowerdir_fd, path, mode) == -1)
 		return errno;
 
-	fd = openat(lowerdir_fd(), path, O_RDONLY);
+	fd = openat(fs->lowerdir_fd, path, O_RDONLY);
 	if (fd == -1)
 		return errno;
 
@@ -1652,7 +1652,7 @@ static int iter_attrs(struct projfs *fs, const char *path,
 	if (nattrs == 0)
 		return 0;
 
-	fd = openat(lowerdir_fd(), path, O_RDONLY);
+	fd = openat(fs->lowerdir_fd, path, O_RDONLY);
 	if (fd == -1)
 		return errno;
 


### PR DESCRIPTION
lowerdir_fd() is a macro which eventually calls fuse_get_context() --
this only works if we're in the same thread as a FUSE operation which
has called one of our callbacks.