### PR TITLE
implement third projection state for files and refine event handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,10 +118,10 @@ AC_SEARCH_LIBS([pthread_create], [pthread], [],
   [AC_MSG_ERROR([POSIX threads library not found])]dnl
 )dnl
 
-AC_CHECK_HEADER([sys/fanotify.h], [],
+AC_CHECK_HEADERS([sys/fanotify.h], [],
   [AC_MSG_ERROR([Linux fanotify header file not found])]dnl
 )dnl
-AC_CHECK_HEADER([sys/inotify.h], [],
+AC_CHECK_HEADERS([sys/inotify.h], [],
   [AC_MSG_ERROR([Linux inotify header file not found])]dnl
 )dnl
 

--- a/include/projfs_notify.h
+++ b/include/projfs_notify.h
@@ -36,11 +36,11 @@ extern "C" {
 #define himask(x)	(((uint64_t)x) << 32)
 
 /** Filesystem events which may be reported */
-#define PROJFS_CLOSE_WRITE	0x00000008	/* Writable file was closed */
-#define PROJFS_DELETE_SELF	0x00000400	/* Delete permission */
-#define PROJFS_MOVE_SELF	0x00000800	/* File/dir was moved */
+#define PROJFS_CLOSE_WRITE	0x00000008	/* Writable file closed */
+#define PROJFS_MOVE		0x000000C0	/* File/dir moved (TO+FROM) */
+#define PROJFS_CREATE		0x00000100	/* File/dir created */
 #define PROJFS_OPEN_PERM	0x00010000	/* File open perm (wr only) */
-#define PROJFS_CREATE_SELF	himask(0x0001)	/* File was created */
+#define PROJFS_DELETE_PERM	himask(0x0001)	/* Delete permission */
 
 /** Filesystem event flags */
 #define PROJFS_ONDIR		0x40000000	/* Event occurred on dir */
@@ -75,8 +75,8 @@ extern "C" {
 #include <sys/inotify.h>
 
 #if (PROJFS_CLOSE_WRITE	!= IN_CLOSE_WRITE ||	\
-     PROJFS_DELETE_SELF	!= IN_DELETE_SELF ||	\
-     PROJFS_MOVE_SELF	!= IN_MOVE_SELF ||	\
+     PROJFS_MOVE	!= IN_MOVE ||	\
+     PROJFS_CREATE	!= IN_CREATE ||	\
      PROJFS_ONDIR	!= IN_ISDIR)
 #error "Projfs notification API out of sync with sys/inotify.h API"
 #endif

--- a/include/projfs_notify.h
+++ b/include/projfs_notify.h
@@ -44,6 +44,7 @@ extern "C" {
 
 /** Filesystem event flags */
 #define PROJFS_ONDIR		0x40000000	/* Event occurred on dir */
+#define PROJFS_ONLINK		himask(0x1000)	/* Event occurred on link */
 
 /** Event permission handler responses */
 #define PROJFS_ALLOW		0x01

--- a/include/projfs_notify.h
+++ b/include/projfs_notify.h
@@ -37,9 +37,9 @@ extern "C" {
 
 /** Filesystem events which may be reported */
 #define PROJFS_CLOSE_WRITE	0x00000008	/* Writable file was closed */
-#define PROJFS_OPEN		0x00000020	/* File was opened */
 #define PROJFS_DELETE_SELF	0x00000400	/* Delete permission */
 #define PROJFS_MOVE_SELF	0x00000800	/* File/dir was moved */
+#define PROJFS_OPEN_PERM	0x00010000	/* File open perm (wr only) */
 #define PROJFS_CREATE_SELF	himask(0x0001)	/* File was created */
 
 /** Filesystem event flags */
@@ -63,7 +63,7 @@ extern "C" {
 #include <sys/fanotify.h>
 
 #if (PROJFS_CLOSE_WRITE	!= FAN_CLOSE_WRITE ||	\
-     PROJFS_OPEN	!= FAN_OPEN ||		\
+     PROJFS_OPEN_PERM	!= FAN_OPEN_PERM ||	\
      PROJFS_ONDIR	!= FAN_ONDIR ||		\
      PROJFS_ALLOW	!= FAN_ALLOW ||		\
      PROJFS_DENY	!= FAN_DENY)
@@ -75,7 +75,6 @@ extern "C" {
 #include <sys/inotify.h>
 
 #if (PROJFS_CLOSE_WRITE	!= IN_CLOSE_WRITE ||	\
-     PROJFS_OPEN	!= IN_OPEN ||		\
      PROJFS_DELETE_SELF	!= IN_DELETE_SELF ||	\
      PROJFS_MOVE_SELF	!= IN_MOVE_SELF ||	\
      PROJFS_ONDIR	!= IN_ISDIR)

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -557,7 +557,12 @@ static int projfs_op_link(char const *src, char const *dst)
 
 	lowerdir_fd = get_fuse_context_lowerdir_fd();
 	res = linkat(lowerdir_fd, src, lowerdir_fd, dst, 0);
-	return res == -1 ? -errno : 0;
+	if (res == -1)
+		return -errno;
+
+	// do not report event handler errors after successful link op
+	send_notify_event(PROJFS_CREATE | PROJFS_ONLINK, src, dst);
+	return 0;
 }
 
 static void *projfs_op_init(struct fuse_conn_info *conn,

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -365,7 +365,7 @@ static int projfs_fuse_proj_locked(uint64_t event_mask,
 {
 	int res = 0;
 
-	if (event_mask & PROJFS_CREATE_SELF)
+	if (event_mask & PROJFS_CREATE)
 		res = projfs_fuse_proj_event(event_mask, path, user->fd);
 	else
 		res = projfs_fuse_perm_event(event_mask, path, NULL);
@@ -424,7 +424,7 @@ static int projfs_fuse_proj_dir(const char *op, const char *path, int parent)
 	/* pass mapped path (i.e. containing directory we want to project) to
 	 * provider */
 	res = projfs_fuse_proj_locked(
-		PROJFS_CREATE_SELF | PROJFS_ONDIR, &user, target_path);
+		PROJFS_CREATE | PROJFS_ONDIR, &user, target_path);
 
 out_finalize:
 	finalize_userdata(&user);
@@ -468,7 +468,7 @@ static int projfs_fuse_proj_file(const char *op, const char *path, int state)
 	if (user.proj_flag == PROJ_XATTR_FLAG_UNOPENED &&
 	    state == PROJ_XATTR_FLAG_UNMODIFIED) {
 		// hydrate empty placeholder file
-		res = projfs_fuse_proj_locked(PROJFS_CREATE_SELF, &user, path);
+		res = projfs_fuse_proj_locked(PROJFS_CREATE, &user, path);
 	} else if (user.proj_flag == PROJ_XATTR_FLAG_UNMODIFIED &&
 		   state == PROJ_XATTR_FLAG_MODIFIED) {
 		// clear flag on modified (full) file
@@ -641,7 +641,7 @@ static int projfs_op_create(char const *path, mode_t mode,
 	fi->fh = fd;
 
 	res = projfs_fuse_notify_event(
-		PROJFS_CREATE_SELF,
+		PROJFS_CREATE,
 		lowerpath(path),
 		NULL);
 	return res;
@@ -742,7 +742,7 @@ static int projfs_op_release(char const *path, struct fuse_file_info *fi)
 static int projfs_op_unlink(char const *path)
 {
 	int res = projfs_fuse_perm_event(
-		PROJFS_DELETE_SELF,
+		PROJFS_DELETE_PERM,
 		lowerpath(path),
 		NULL);
 	if (res < 0)
@@ -765,7 +765,7 @@ static int projfs_op_mkdir(char const *path, mode_t mode)
 		return -errno;
 
 	res = projfs_fuse_notify_event(
-		PROJFS_CREATE_SELF | PROJFS_ONDIR,
+		PROJFS_CREATE | PROJFS_ONDIR,
 		lowerpath(path),
 		NULL);
 	return res;
@@ -774,7 +774,7 @@ static int projfs_op_mkdir(char const *path, mode_t mode)
 static int projfs_op_rmdir(char const *path)
 {
 	int res = projfs_fuse_perm_event(
-		PROJFS_DELETE_SELF | PROJFS_ONDIR,
+		PROJFS_DELETE_PERM | PROJFS_ONDIR,
 		lowerpath(path),
 		NULL);
 	if (res < 0)
@@ -790,7 +790,7 @@ static int projfs_op_rmdir(char const *path)
 static int projfs_op_rename(char const *src, char const *dst,
                             unsigned int flags)
 {
-	uint64_t mask = PROJFS_MOVE_SELF;
+	uint64_t mask = PROJFS_MOVE;
 
 	int res = projfs_fuse_proj_dir("rename", lowerpath(src), 1);
 	if (res)

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -152,7 +152,7 @@ static int projfs_fuse_perm_event(uint64_t mask,
 
 #define PROJ_XATTR_PRE_NAME "user.projection."
 #define PROJ_XATTR_PRE_LEN (sizeof(PROJ_XATTR_PRE_NAME) - 1)
-#define PROJ_XATTR_EMPTY PROJ_XATTR_PRE_NAME"empty"
+#define PROJ_XATTR_FLAG_NAME PROJ_XATTR_PRE_NAME"empty"
 
 static int xattr_name_has_prefix(const char *name)
 {
@@ -164,7 +164,7 @@ static int xattr_name_has_prefix(const char *name)
 
 static int xattr_name_is_reserved(const char *name)
 {
-	if (strcmp(name, PROJ_XATTR_EMPTY) == 0)
+	if (strcmp(name, PROJ_XATTR_FLAG_NAME) == 0)
 		return 1;
 	// add other reserved names as they are defined
 
@@ -200,7 +200,7 @@ static int get_xattr_projflag(int fd)
 {
 	ssize_t size = 0;
 
-	if (get_xattr(fd, PROJ_XATTR_EMPTY, NULL, &size) == -1)
+	if (get_xattr(fd, PROJ_XATTR_FLAG_NAME, NULL, &size) == -1)
 		return -1;
 	return (size == -1) ? 0 : 1;
 }
@@ -209,14 +209,14 @@ static int set_xattr_projflag(int fd, int flags)
 {
 	ssize_t size = 1;
 
-	return set_xattr(fd, PROJ_XATTR_EMPTY, "y", &size, flags);
+	return set_xattr(fd, PROJ_XATTR_FLAG_NAME, "y", &size, flags);
 }
 
 static int remove_xattr_projflag(int fd)
 {
 	ssize_t size = 0;
 
-	return set_xattr(fd, PROJ_XATTR_EMPTY, NULL, &size, 0);
+	return set_xattr(fd, PROJ_XATTR_FLAG_NAME, NULL, &size, 0);
 }
 
 struct node_userdata
@@ -247,7 +247,7 @@ static char *get_path_parent(char const *path)
 /**
  * Acquires a lock on path and populates the supplied node_userdata argument
  * with the open and locked fd, and proj_flag based on the
- * PROJ_XATTR_EMPTY xattr.
+ * PROJ_XATTR_FLAG_NAME xattr.
  *
  * @param user userdata to fill out (zeroed by this function)
  * @param path path relative to lowerdir to lock and open

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -222,8 +222,7 @@ static int remove_xattr_projflag(int fd)
 struct node_userdata
 {
 	int fd;
-
-	uint8_t proj_flag;
+	int proj_flag;
 };
 
 /**

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -96,11 +96,13 @@ static int projfs_fuse_send_event(projfs_handler_t handler,
 
 	err = handler(&event);
 	if (err < 0) {
+		// TODO: replace with log output and only when log option set
 		fprintf(stderr, "projfs: event handler failed: %s; "
 		                "event mask 0x%04" PRIx64 "-%08" PRIx64 ", "
-		                "pid %d\n",
+		                "pid %d, path %s, target path %s\n",
 		        strerror(-err), mask >> 32, mask & 0xFFFFFFFF,
-		        event.pid);
+		        event.pid, path,
+			(target_path == NULL) ? "" : target_path);
 	}
 	else if (!fd && perm)
 		err = (err == PROJFS_ALLOW) ? 0 : -EPERM;

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -650,8 +650,9 @@ static int projfs_op_create(char const *path, mode_t mode,
 		return -errno;
 	fi->fh = fd;
 
-	res = send_notify_event(PROJFS_CREATE, path, NULL);
-	return res;
+	// do not report event handler errors after successful open op
+	send_notify_event(PROJFS_CREATE, path, NULL);
+	return 0;
 }
 
 #define has_write_mode(fi) ((fi)->flags & (O_WRONLY | O_RDWR))
@@ -773,8 +774,9 @@ static int projfs_op_mkdir(char const *path, mode_t mode)
 	if (res == -1)
 		return -errno;
 
-	res = send_notify_event(PROJFS_CREATE | PROJFS_ONDIR, path, NULL);
-	return res;
+	// do not report event handler errors after successful mkdir op
+	send_notify_event(PROJFS_CREATE | PROJFS_ONDIR, path, NULL);
+	return 0;
 }
 
 static int projfs_op_rmdir(char const *path)
@@ -823,8 +825,9 @@ static int projfs_op_rename(char const *src, char const *dst,
 	if (res == -1)
 		return -errno;
 
-	res = send_notify_event(mask, src, dst);
-	return res;
+	// do not report event handler errors after successful rename op
+	send_notify_event(mask, src, dst);
+	return 0;
 }
 
 static int projfs_op_opendir(char const *path, struct fuse_file_info *fi)

--- a/t/t200-event-ok.t
+++ b/t/t200-event-ok.t
@@ -66,6 +66,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission granted on top-level file deletion' '
 	projfs_event_exec rm target/f1a.txt &&

--- a/t/t201-event-err.t
+++ b/t/t201-event-err.t
@@ -59,6 +59,14 @@ test_expect_success 'test event handler error on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+# TODO: we expect ln to link a file despite the handler error and
+#	to not report a failure exit code
+projfs_event_printf error ENOMEM notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler error on file hard link' '
+	test_might_fail projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf error ENOMEM perm delete_file f1a.txt
 test_expect_success 'test event handler error on file deletion' '
 	test_must_fail projfs_event_exec rm target/f1a.txt &&

--- a/t/t201-event-err.t
+++ b/t/t201-event-err.t
@@ -28,10 +28,10 @@ projfs_start test_handlers source target --retval-file retval || exit 1
 echo ENOMEM > retval
 
 # TODO: we expect mkdir to create a dir despite the handler error and
-#	regardless of mkdir's failure exit code
+#	to not report a failure exit code
 projfs_event_printf error ENOMEM notify create_dir d1
 test_expect_success 'test event handler error on directory creation' '
-	test_must_fail projfs_event_exec mkdir target/d1 &&
+	test_might_fail projfs_event_exec mkdir target/d1 &&
 	test_path_is_dir target/d1
 '
 
@@ -44,18 +44,18 @@ test_expect_success 'test event handler error on file creation' '
 '
 
 # TODO: we expect mv to rename a dir despite the handler error and
-#	regardless of mv's failure exit code
+#	to not report a failure exit code
 projfs_event_printf error ENOMEM notify rename_dir d1 d1a
 test_expect_success 'test event handler error on directory rename' '
-	test_must_fail projfs_event_exec mv target/d1 target/d1a &&
+	test_might_fail projfs_event_exec mv target/d1 target/d1a &&
 	test_path_is_dir target/d1a
 '
 
 # TODO: we expect mv to rename a file despite the handler error and
-#	regardless of mv's failure exit code
+#	to not report a failure exit code
 projfs_event_printf error ENOMEM notify rename_file f1.txt f1a.txt
 test_expect_success 'test event handler error on file rename' '
-	test_must_fail projfs_event_exec mv target/f1.txt target/f1a.txt &&
+	test_might_fail projfs_event_exec mv target/f1.txt target/f1a.txt &&
 	test_path_is_file target/f1a.txt
 '
 

--- a/t/t202-event-deny.t
+++ b/t/t202-event-deny.t
@@ -53,6 +53,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission request denied on file deletion' '
 	test_must_fail projfs_event_exec rm target/f1a.txt &&

--- a/t/t203-event-null.t
+++ b/t/t203-event-null.t
@@ -53,6 +53,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission request denied on file deletion' '
 	test_must_fail projfs_event_exec rm target/f1a.txt &&

--- a/t/t204-event-allow.t
+++ b/t/t204-event-allow.t
@@ -53,6 +53,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission request allowed on file deletion' '
 	projfs_event_exec rm target/f1a.txt &&

--- a/t/t205-event-locking.t
+++ b/t/t205-event-locking.t
@@ -26,7 +26,7 @@ given path.
 projfs_start test_handlers source target --timeout 1 --lock-file lock || exit 1
 
 # wait_mount will trigger a projection, so we need to reset it to empty
-setfattr -n user.projection.empty -v 0x01 source
+setfattr -n user.projection.empty -v y source
 
 test_expect_success 'test concurrent access does not trigger failure' '
 	projfs_run_twice ls target

--- a/t/test-lib-event.sh
+++ b/t/test-lib-event.sh
@@ -21,13 +21,13 @@ EVENT_ERR="expect.event.err"
 event_msg_notify="test event notification for"
 event_msg_perm="test permission request for"
 
-event_delete_dir="0x0000-40000400"
-event_rename_dir="0x0000-40000800"
-event_create_dir="0x0001-40000000"
+event_rename_dir="0x0000-400000c0"
+event_create_dir="0x0000-40000100"
+event_delete_dir="0x0001-40000000"
 
-event_delete_file="0x0000-00000400"
-event_rename_file="0x0000-00000800"
-event_create_file="0x0001-00000000"
+event_rename_file="0x0000-000000c0"
+event_create_file="0x0000-00000100"
+event_delete_file="0x0001-00000000"
 
 # Format into "$event_msg_head" and "$event_err_msg" log and error messages
 # matching those output by the test mount helper programs.

--- a/t/test-lib-event.sh
+++ b/t/test-lib-event.sh
@@ -30,6 +30,7 @@ event_delete_dir="0x0001-40000000"
 event_rename_file="0x0000-000000c0"
 event_create_file="0x0000-00000100"
 event_delete_file="0x0001-00000000"
+event_link_file="0x1000-00000100"
 
 NL=$(printf "\nx")
 NL="${NL%%x}"

--- a/t/test-lib-event.sh
+++ b/t/test-lib-event.sh
@@ -35,7 +35,7 @@ NL=$(printf "\nx")
 NL="${NL%%x}"
 
 LOG_FMT='  %s %s%s: %s, %s'
-ERR_FMT='%s: %s; event mask %s, pid %s'
+ERR_FMT='%s: %s; event mask %s, pid %s, path %s, target path %s'
 
 # Format into "$event_log_msgs" and "$event_err_msgs" log and error messages
 # matching those output by the test mount helper programs.
@@ -73,7 +73,8 @@ projfs_event_printf () {
 	if test ":$err" != ":"
 	then
 		err_msg=$(printf "$ERR_FMT" \
-			"$event_msg_err" "$err" "$code" "$EXEC_PID_MARK")
+			"$event_msg_err" "$err" "$code" "$EXEC_PID_MARK" \
+			"$3" "$4")
 
 		event_err_msgs="${event_err_msgs:+$event_err_msgs$NL}$err_msg"
 	fi

--- a/t/test_handlers.c
+++ b/t/test_handlers.c
@@ -52,7 +52,7 @@ static int test_handle_event(struct projfs_event *event, const char *desc,
 	}
 
 	if (proj) {
-		if ((event->mask & ~PROJFS_ONDIR) != PROJFS_CREATE_SELF) {
+		if ((event->mask & ~PROJFS_ONDIR) != PROJFS_CREATE) {
 			fprintf(stderr, "unknown projection flags\n");
 			ret = -EINVAL;
 		}


### PR DESCRIPTION
The primary goal of this PR is to address #65 and implement a third state for projected files, i.e.:
&nbsp;&nbsp;&nbsp;empty -> populated (hydrated) -> modified (full)

There are a number of other small but notable functional changes:
- better alignment of our event bitmasks with the inotify and fanotify APIs
- projection of directories when `open(2)` is called on them
- errors from post-operation notification event handlers are not returned to the caller

The latter change ensures that a caller which, say, calls `creat(2)` on a file and has that operation succeed, but the post-operation event notification fail, still knows there is a new file descriptor resource they should close; an error return would imply the file had not been opened.

The test suite is slightly modified to accommodate these functional changes, and also is revised to support multiple event messages per test.  This isn't exercised yet, but will be necessary when we add the remaining events, particularly the file-modified one.

Finally, the additional file state prompted a fair bit of tinkering with the existing projection logic functions, and that in turn led me to take on some internal renaming and code path tidying, which I hope makes the final result a fair bit cleaner and easier to follow.  It may, however, be simpler to review by looking at the individual step-by-step commits than the final full diff.