### PR TITLE
add event notification on hard link creation

### DIFF
--- a/include/projfs_notify.h
+++ b/include/projfs_notify.h
@@ -44,6 +44,7 @@ extern "C" {
 
 /** Filesystem event flags */
 #define PROJFS_ONDIR		0x40000000	/* Event occurred on dir */
+#define PROJFS_ONLINK		himask(0x1000)	/* Event occurred on link */
 
 /** Event permission handler responses */
 #define PROJFS_ALLOW		0x01

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -557,7 +557,12 @@ static int projfs_op_link(char const *src, char const *dst)
 
 	lowerdir_fd = get_fuse_context_lowerdir_fd();
 	res = linkat(lowerdir_fd, src, lowerdir_fd, dst, 0);
-	return res == -1 ? -errno : 0;
+	if (res == -1)
+		return -errno;
+
+	// do not report event handler errors after successful link op
+	send_notify_event(PROJFS_CREATE | PROJFS_ONLINK, src, dst);
+	return 0;
 }
 
 static void *projfs_op_init(struct fuse_conn_info *conn,

--- a/t/t200-event-ok.t
+++ b/t/t200-event-ok.t
@@ -66,6 +66,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission granted on top-level file deletion' '
 	projfs_event_exec rm target/f1a.txt &&

--- a/t/t201-event-err.t
+++ b/t/t201-event-err.t
@@ -59,6 +59,14 @@ test_expect_success 'test event handler error on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+# TODO: we expect ln to link a file despite the handler error and
+#	to not report a failure exit code
+projfs_event_printf error ENOMEM notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler error on file hard link' '
+	test_might_fail projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf error ENOMEM perm delete_file f1a.txt
 test_expect_success 'test event handler error on file deletion' '
 	test_must_fail projfs_event_exec rm target/f1a.txt &&

--- a/t/t202-event-deny.t
+++ b/t/t202-event-deny.t
@@ -53,6 +53,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission request denied on file deletion' '
 	test_must_fail projfs_event_exec rm target/f1a.txt &&

--- a/t/t203-event-null.t
+++ b/t/t203-event-null.t
@@ -53,6 +53,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission request denied on file deletion' '
 	test_must_fail projfs_event_exec rm target/f1a.txt &&

--- a/t/t204-event-allow.t
+++ b/t/t204-event-allow.t
@@ -53,6 +53,12 @@ test_expect_success 'test event handler on file rename' '
 	test_path_is_file target/f1a.txt
 '
 
+projfs_event_printf notify link_file f1a.txt l1a.txt
+test_expect_success 'test event handler on file hard link' '
+	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
+	test_path_is_file target/l1a.txt
+'
+
 projfs_event_printf perm delete_file f1a.txt
 test_expect_success 'test permission request allowed on file deletion' '
 	projfs_event_exec rm target/f1a.txt &&

--- a/t/test-lib-event.sh
+++ b/t/test-lib-event.sh
@@ -30,6 +30,7 @@ event_delete_dir="0x0001-40000000"
 event_rename_file="0x0000-000000c0"
 event_create_file="0x0000-00000100"
 event_delete_file="0x0001-00000000"
+event_link_file="0x1000-00000100"
 
 NL=$(printf "\nx")
 NL="${NL%%x}"


### PR DESCRIPTION
This PR adds a simple post-operation event notification when a hard link is created, which then maps to the VFSForGit `OnHardLinkCreated` handler.

Rather than propose a merge into master, I thought it might be simpler to merge this into the xattr-tristate branch from PR #66 first, but am open to redoing it against master.