### PR TITLE
add CLOSE_WRITE event notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /include/config.h.in
 /include/stamp-h*
 /install-sh
+/lib/.dirstamp
 /libtool
 /libprojfs-*.tar.*z
 /ltmain.sh

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -25,6 +25,7 @@ AM_LDFLAGS = $(WARN_LDFLAGS)
 lib_LTLIBRARIES = libprojfs.la
 
 libprojfs_la_SOURCES = projfs.c \
+		       fdtable.c fdtable.h \
 		       $(top_srcdir)/include/projfs.h \
 		       $(top_srcdir)/include/projfs_notify.h
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -31,3 +31,6 @@ libprojfs_la_SOURCES = projfs.c \
 
 libprojfs_la_LDFLAGS = -version-number 0:0:0 -export-symbols-regex "^projfs"
 
+clean-local:
+	$(RM) .dirstamp
+

--- a/lib/fdtable.c
+++ b/lib/fdtable.c
@@ -1,0 +1,317 @@
+/* Linux Projected Filesystem
+   Copyright (C) 2019 GitHub, Inc.
+
+   See the NOTICE file distributed with this library for additional
+   information regarding copyright ownership.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library, in the file COPYING; if not,
+   see <http://www.gnu.org/licenses/>.
+*/
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "fdtable.h"
+
+/*
+ * We implement an open-addressed hash table with linear probing,
+ * using a single array containing both keys (file descriptors)
+ * and values (pids).
+ *
+ * Because fds are guaranteed to be non-negative, we can also use the key of
+ * each pair to store 'empty' and 'removed' sentinels as negative integers.
+ *
+ * Our array size is always a power of two, to simplify reducing our hash
+ * values to smaller index values.  As we need to keep the load factor of
+ * our table below 0.7, we resize the array when the number of stored keys
+ * is greater than 2/3 the array length, or less than 1/6 the array length.
+ *
+ * For our present purposes we can assume all lookups succeed, including
+ * insertions (since fds are unique, there can be no conflicts), and all
+ * removals, as we remove only during the FUSE release operation, which is
+ * guaranteed to be called exactly once per fd.
+ *
+ * We don't split our keys and values into distinct arrays as testing
+ * indicates that successful lookup poperations are slightly faster with a
+ * single array, given our very small data size (typically eight bytes per
+ * key/value pair).  Since we expect to never have failed lookups, distinct
+ * key and value arrays do not appear to give any performance advantage.
+ *
+ * While file descriptors generally increase monotonically, we can't rely
+ * on that universally, as the Linux VFS will recycle descriptors which have
+ * been closed.
+ *
+ * The number of table entries we have to probe in the case of collisions
+ * of our hash function is minimized, given our often near-sequential
+ * keys, by using an implementation of Knuth's multiplicative (Fibonacci)
+ * hashing with a prime factor very near the product of 2^32 and the golden
+ * ratio conjugate (captial Phi), as described in:
+ *
+ * https://dl.acm.org/citation.cfm?id=1268381
+ * http://www.citi.umich.edu/projects/linux-scalability/reports/hash.html
+ *
+ * https://en.wikipedia.org/wiki/Universal_hashing#Avoiding_modular_arithmetic
+ *
+ * While many sources emphasize use of the high bits of the full hash value
+ * when reducing to an array index, testing with both random and,
+ * especially, sequential and mostly-sequential key values indicates we
+ * achieve more single-probe-only lookups and shorter maximum probe lengths
+ * when using the lower bits of the hash for the array index.
+ */
+
+struct fd_pid_entry {
+	int fd;
+	pid_t pid;
+};
+
+struct fdtable {
+	unsigned int size;
+	unsigned int used;
+	uint32_t mask;
+	long l1cache_linesize;
+	struct fd_pid_entry *array;
+	pthread_mutex_t mutex;
+};
+
+#define DEFAULT_CACHE_LINESIZE 64
+
+#define DEFAULT_TABLE_SIZE 32
+#define MIN_TABLE_SIZE DEFAULT_TABLE_SIZE
+
+static int create_array(struct fdtable *table, unsigned int table_size)
+{
+	void *array;
+	size_t array_bytes;
+
+	array_bytes = table_size * sizeof(*table->array);
+
+	if (posix_memalign(&array, table->l1cache_linesize,
+			   array_bytes) != 0) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	// fill array with int values corresponding to SENTINEL_EMPTY (-1)
+	memset(array, 0xFF, array_bytes);
+
+	table->size = table_size;
+	table->mask = table_size - 1;
+	table->array = array;
+
+	return 0;
+}
+
+struct fdtable *fdtable_create(void)
+{
+	struct fdtable *table;
+
+	table = calloc(1, sizeof(*table));
+	if (table == NULL)
+		return NULL;
+
+	table->l1cache_linesize = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+	if (table->l1cache_linesize == -1)
+		table->l1cache_linesize = DEFAULT_CACHE_LINESIZE;
+
+	if (create_array(table, DEFAULT_TABLE_SIZE) == -1)
+		goto out_table;
+
+	if (pthread_mutex_init(&table->mutex, NULL) != 0)
+		goto out_array;
+
+	return table;
+
+out_array:
+	free(table->array);
+out_table:
+	free(table);
+	return NULL;
+}
+
+#define SENTINEL_EMPTY -1
+#define SENTINEL_REMOVED -2
+
+enum entry_operation {
+	OP_INSERT = 0,
+	OP_REHASH,
+	OP_REPLACE,
+	OP_REMOVE
+};
+
+enum update_result {
+	UPDATE_ERROR = -1,
+	UPDATE_SUCCESS,
+	UPDATE_CONTINUE
+};
+
+static enum update_result
+try_update_entry(struct fdtable *table, unsigned int index,
+		 int fd, pid_t *pid, enum entry_operation op)
+{
+	struct fd_pid_entry *entry = &table->array[index];
+	int entry_fd = entry->fd;
+
+	switch (op) {
+	case OP_INSERT:
+	case OP_REHASH:
+		if (entry_fd > SENTINEL_EMPTY)
+			return UPDATE_CONTINUE;
+		entry->fd = fd;
+		entry->pid = *pid;
+		if (op == OP_INSERT)
+			++table->used;
+		break;
+	case OP_REPLACE:
+	case OP_REMOVE:
+		if (entry_fd == fd) {
+			if (op == OP_REPLACE) {
+				entry->pid = *pid;
+			} else {
+				entry->fd = SENTINEL_REMOVED;
+				*pid = entry->pid;
+				--table->used;
+			}
+		} else {
+			/* We should never reach the end of a cluster of
+			 * entries; this would imply a FUSE error.
+			 */
+			return (entry_fd == SENTINEL_EMPTY) ? UPDATE_ERROR
+							    : UPDATE_CONTINUE;
+		}
+	default:
+		break;
+	}
+
+	return UPDATE_SUCCESS;
+}
+
+// prime near 2^32 * golden ratio conjugate
+#define GOLDEN_RATIO_PRIME 2654435761U
+
+static inline unsigned int hash32_index(uint32_t key, uint32_t mask)
+{
+	return (key * GOLDEN_RATIO_PRIME) & mask;
+}
+
+static int update_entry(struct fdtable *table, int fd, pid_t *pid,
+			enum entry_operation op)
+{
+	unsigned int index = hash32_index(fd, table->mask);
+	unsigned int i;
+	enum update_result res;
+
+	for (i = index; i < table->size; ++i) {
+		res = try_update_entry(table, i, fd, pid, op);
+		if (res != UPDATE_CONTINUE)
+			return (res == UPDATE_SUCCESS) ? 0 : -1;
+	}
+	for (i = 0; i < index; ++i) {
+		res = try_update_entry(table, i, fd, pid, op);
+		if (res != UPDATE_CONTINUE)
+			return (res == UPDATE_SUCCESS) ? 0 : -1;
+	}
+
+	/* We should never exhaust our table as we resize before updating
+	 * (or fail while resizing), so we should never reach here.
+	 */
+	return -1;
+}
+
+static int resize_table(struct fdtable *table, unsigned int new_size)
+{
+	struct fd_pid_entry *array = table->array;
+	unsigned int old_size = table->size;
+	unsigned int i;
+
+	if (new_size > MAX_TABLE_SIZE) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	if (create_array(table, new_size) == -1)
+		return -1;
+
+	for (i = 0; i < old_size; ++i) {
+		if (array[i].fd < 0)
+			continue;
+		// we know table size is sufficient so ignore return code
+		(void)update_entry(table, array[i].fd, &array[i].pid,
+				   OP_REHASH);
+	}
+
+	return 0;
+}
+
+#define max_load(sz) (2 * (sz) / 3)
+#define min_load(sz) (1 * (sz) / 6)
+
+int fdtable_insert(struct fdtable *table, int fd, pid_t pid)
+{
+	int ret;
+
+	pthread_mutex_lock(&table->mutex);
+
+	if (table->used + 1 > max_load(table->size)) {
+		ret = resize_table(table, table->size * 2);
+		if (ret == -1)
+			goto out;
+	}
+	ret = update_entry(table, fd, &pid, OP_INSERT);
+
+out:
+	pthread_mutex_unlock(&table->mutex);
+	return ret;
+}
+
+int fdtable_replace(struct fdtable *table, int fd, pid_t pid)
+{
+	int ret;
+
+	pthread_mutex_lock(&table->mutex);
+	ret = update_entry(table, fd, &pid, OP_REPLACE);
+	pthread_mutex_unlock(&table->mutex);
+	return ret;
+}
+
+int fdtable_remove(struct fdtable *table, int fd, pid_t *pid)
+{
+	int ret;
+
+	pthread_mutex_lock(&table->mutex);
+
+	if (table->size > MIN_TABLE_SIZE &&
+	    table->used - 1 < min_load(table->size)) {
+		ret = resize_table(table, table->size / 2);
+		if (ret == -1)
+			goto out;
+	}
+	ret = update_entry(table, fd, pid, OP_REMOVE);
+
+out:
+	pthread_mutex_unlock(&table->mutex);
+	return ret;
+}
+
+void fdtable_destroy(struct fdtable *table)
+{
+	pthread_mutex_destroy(&table->mutex);
+	free(table->array);
+	free(table);
+}

--- a/lib/fdtable.h
+++ b/lib/fdtable.h
@@ -1,0 +1,36 @@
+/* Linux Projected Filesystem
+   Copyright (C) 2019 GitHub, Inc.
+
+   See the NOTICE file distributed with this library for additional
+   information regarding copyright ownership.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library, in the file COPYING; if not,
+   see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _FDTABLE_H
+#define _FDTABLE_H
+
+#define MAX_TABLE_SIZE 65536
+
+struct fdtable;
+
+struct fdtable *fdtable_create(void);
+void fdtable_destroy(struct fdtable *table);
+
+int fdtable_insert(struct fdtable *table, int fd, pid_t pid);
+int fdtable_replace(struct fdtable *table, int fd, pid_t pid);
+int fdtable_remove(struct fdtable *table, int fd, pid_t *pid);
+
+#endif /* _FDTABLE_H */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -27,11 +27,14 @@ test_common = test_common.c \
 	      $(top_srcdir)/include/projfs_notify.h
 
 check_PROGRAMS = get_strerror \
+		 test_fdtable \
 		 test_handlers \
 		 test_simple \
 		 wait_mount
 
 get_strerror_SOURCES = get_strerror.c $(test_common)
+test_fdtable_SOURCES = test_fdtable.c $(test_common) \
+		       ../lib/fdtable.c ../lib/fdtable.h
 test_handlers_SOURCES = test_handlers.c $(test_common)
 test_simple_SOURCES = test_simple.c $(test_common)
 wait_mount_SOURCES = wait_mount.c $(test_common)
@@ -44,6 +47,7 @@ TESTS = t000-mirror-read.t \
 	t005-mirror-links.t \
 	t006-mirror-statfs.t \
 	t007-mirror-attrs.t \
+	t100-fdtable-fill.t \
 	t200-event-ok.t \
 	t201-event-err.t \
 	t202-event-deny.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -87,13 +87,14 @@ prove: clean-mounts $(check_PROGRAMS)
 	fi
 
 clean-mounts:
-	@./clean_test_dirs.sh
+	./clean_test_dirs.sh
 
 clean-mounts-output:
-	@./clean_test_dirs.sh --all
+	./clean_test_dirs.sh --all
 
 clean-prove:
-	@$(RM) $(PROVE_FILE)
+	$(RM) $(PROVE_FILE)
 
 clean-local: clean-mounts-output clean-prove
+	$(RM) ../lib/.dirstamp
 

--- a/t/t100-fdtable-fill.t
+++ b/t/t100-fdtable-fill.t
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Copyright (C) 2019 GitHub, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/ .
+
+test_description='projfs file descriptor table fill test
+
+Check that the file descriptor hash table grows to its maximum size.
+'
+
+. ./test-lib.sh
+
+test_expect_success 'check fdtable fill operations' '
+	"$TEST_DIRECTORY/test_fdtable"
+'
+
+test_done
+

--- a/t/t200-event-ok.t
+++ b/t/t200-event-ok.t
@@ -42,12 +42,14 @@ test_expect_success 'test event handler on nested directory creation' '
 # TODO: also use 'echo ... >' to exercise open() not create()
 
 projfs_event_printf notify create_file f1.txt
+projfs_event_printf notify close_file f1.txt
 test_expect_success 'test event handler on top-level file creation' '
 	projfs_event_exec touch target/f1.txt &&
 	test_path_is_file target/f1.txt
 '
 
 projfs_event_printf notify create_file d1/d2/f2.txt
+projfs_event_printf notify close_file d1/d2/f2.txt
 test_expect_success 'test event handler on nested file creation' '
 	projfs_event_exec touch target/d1/d2/f2.txt &&
 	test_path_is_file target/d1/d2/f2.txt

--- a/t/t201-event-err.t
+++ b/t/t201-event-err.t
@@ -38,6 +38,7 @@ test_expect_success 'test event handler error on directory creation' '
 # TODO: we expect touch to create a file despite the handler error and
 #	to not report a failure exit code
 projfs_event_printf error ENOMEM notify create_file f1.txt
+projfs_event_printf error ENOMEM notify close_file f1.txt
 test_expect_success 'test event handler error on file creation' '
 	test_might_fail projfs_event_exec touch target/f1.txt &&
 	test_path_is_file target/f1.txt

--- a/t/t202-event-deny.t
+++ b/t/t202-event-deny.t
@@ -34,6 +34,7 @@ test_expect_success 'test event handler on directory creation' '
 '
 
 projfs_event_printf notify create_file f1.txt
+projfs_event_printf notify close_file f1.txt
 test_expect_success 'test event handler on file creation' '
 	projfs_event_exec touch target/f1.txt &&
 	test_path_is_file target/f1.txt

--- a/t/t203-event-null.t
+++ b/t/t203-event-null.t
@@ -34,6 +34,7 @@ test_expect_success 'test event handler on directory creation' '
 '
 
 projfs_event_printf notify create_file f1.txt
+projfs_event_printf notify close_file f1.txt
 test_expect_success 'test event handler on file creation' '
 	projfs_event_exec touch target/f1.txt &&
 	test_path_is_file target/f1.txt

--- a/t/t204-event-allow.t
+++ b/t/t204-event-allow.t
@@ -34,6 +34,7 @@ test_expect_success 'test event handler on directory creation' '
 '
 
 projfs_event_printf notify create_file f1.txt
+projfs_event_printf notify close_file f1.txt
 test_expect_success 'test event handler on file creation' '
 	projfs_event_exec touch target/f1.txt &&
 	test_path_is_file target/f1.txt

--- a/t/test-lib-event.sh
+++ b/t/test-lib-event.sh
@@ -27,6 +27,7 @@ event_rename_dir="0x0000-400000c0"
 event_create_dir="0x0000-40000100"
 event_delete_dir="0x0001-40000000"
 
+event_close_file="0x0000-00000008"
 event_rename_file="0x0000-000000c0"
 event_create_file="0x0000-00000100"
 event_delete_file="0x0001-00000000"

--- a/t/test_fdtable.c
+++ b/t/test_fdtable.c
@@ -1,0 +1,139 @@
+/* Linux Projected Filesystem
+   Copyright (C) 2019 GitHub, Inc.
+
+   See the NOTICE file distributed with this library for additional
+   information regarding copyright ownership.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library, in the file COPYING; if not,
+   see <http://www.gnu.org/licenses/>.
+*/
+
+#include <limits.h>
+#include <stdlib.h>
+#include <sys/time.h>
+
+#include "../lib/fdtable.h"
+#include "test_common.h"
+
+static pid_t pids[MAX_TABLE_SIZE];
+
+static pid_t get_random_pid(void)
+{
+	return (random() & (INT_MAX >> 1)) + 1;
+}
+
+static void test_insert(const char *argv0, struct fdtable *table, int fd)
+{
+	pid_t pid = get_random_pid();
+
+	if (fdtable_insert(table, fd, pid) == -1) {
+		test_exit_error(argv0, "unable to insert entry with key %d "
+				       "and value %d; table may be full",
+				fd, pid);
+	}
+	pids[fd] = pid;
+}
+
+static void test_replace(const char *argv0, struct fdtable *table, int fd)
+{
+	pid_t pid = get_random_pid();
+
+	if (fdtable_replace(table, fd, pid) == -1) {
+		test_exit_error(argv0, "unable to replace entry with key %d "
+				       "and value %d; key not found",
+				fd, pid);
+	}
+	pids[fd] = pid;
+}
+
+static int test_remove(const char *argv0, struct fdtable *table, int fd)
+{
+	pid_t pid;
+	int ret;
+
+	ret = fdtable_remove(table, fd, &pid);
+	if (ret == -1 && pids[fd] > 0) {
+		test_exit_error(argv0, "unable to remove entry with key %d "
+				       "and value %d; key not found",
+				fd, pids[fd]);
+	} else if (ret == 0 && pid != pids[fd]) {
+		test_exit_error(argv0, "incorrect entry with value %d "
+				       "removed for key %d; correct value %d",
+				pid, fd, pids[fd]);
+	} else if (ret == 0) {
+		pids[fd] = 0;
+	}
+	return ret;
+}
+
+int main(int argc, char *const argv[])
+{
+	struct fdtable *table;
+	struct timeval tv;
+	unsigned int max_load = 2 * MAX_TABLE_SIZE / 3;
+	unsigned int min_load = MAX_TABLE_SIZE / 2;
+	unsigned int load_range = max_load - min_load;
+	unsigned int load = 0;
+	unsigned int target = 0;
+	int fd, i;
+
+	gettimeofday(&tv, NULL);
+	srandom(tv.tv_sec + tv.tv_usec);
+
+	table = fdtable_create();
+	if (table == NULL)
+		test_exit_error(argv[0], "unable to create fdtable");
+
+	for (i = 0; i < MAX_TABLE_SIZE * 10; ++i) {
+		while (target == load)
+			target = random() % load_range + min_load;
+
+		fd = random() & (MAX_TABLE_SIZE - 1);
+		if (target > load) {
+			if (pids[fd] == 0) {
+				test_insert(argv[0], table, fd);
+				++load;
+			} else {
+				test_replace(argv[0], table, fd);
+			}
+		} else {
+			if (test_remove(argv[0], table, fd) == 0)
+				--load;
+		}
+	}
+
+	while (load < max_load) {
+		fd = random() & (MAX_TABLE_SIZE - 1);
+		if (pids[fd] == 0) {
+			test_insert(argv[0], table, fd);
+			++load;
+		}
+	}
+
+	fd = 0;
+	while (pids[fd] > 0)
+		++fd;
+	if (fdtable_insert(table, fd, 1) != -1) {
+		test_exit_error(argv[0], "insert above maximum table size "
+					 "and load factor succeeded");
+	}
+
+	for (i = 0; i < MAX_TABLE_SIZE; ++i)
+		test_remove(argv[0], table, i);
+
+	fdtable_destroy(table);
+
+	exit(EXIT_SUCCESS);
+}
+


### PR DESCRIPTION
In order to implement the `OnFileModified` event notification required by VFSForGit (as described in #63), we send an event when a file which was opened for writing is fully closed.  In order to align with inotify, we use the `CLOSE_WRITE` event mask for these events.

To report the `CLOSE_WRITE` event reliably, and only once per file descriptor, we deliver it from the FUSE `release` operation.  We don't report from the `flush` operation, as that may be called multiple times per open file descriptor, or not at all, while `release` is always called exactly once per descriptor.

However, the `release` operation's FUSE context no longer has the pid of the process which owned the file descriptor.  Therefore we track the pid of the process which opened a file for writing, or most recently closed that file (thus sending a FUSE `flush` operation), and use that pid as our best effort in our `CLOSE_WRITE` event notification.

Note that directories can not be opened with write flags, so our pid tracking and `CLOSE_WRITE` event notification will not apply to them, even if they are opened with `open(2)`.

Tracking the pid associated most recently with each file descriptor is not, obviously, perfect, but is our best option in the circumstances.  Ideally we would be able to do this within a FUSE structure like [`struct node`](https://github.com/libfuse/libfuse/blob/f2df33e020bce864d9a685b998d80c5203ef23a9/lib/fuse.c#L142) but that would of course imply we stop using the FUSE high-level API, with the attendant issues of then managing inode-to-path mappings ourselves.

Fortunately, file descriptors and pids are both simple integers, and moreover, file descriptors are unique and tend to be allocated with runs of sequential values, so we can optimize our hash table for these conditions; see the comments inline in `lib/fdtable.c` for details.