### PR TITLE
Avoid blocking or failing when attempting to project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /configure
 /depcomp
 /include/config.h
-/include/config.h.in
+/include/config.h.in*
 /include/stamp-h*
 /install-sh
 /lib/.dirstamp

--- a/docs/design.md
+++ b/docs/design.md
@@ -512,6 +512,22 @@ instead of in kernel mode.
 
 ![Diagram of phase 1 of the Linux implementation](images/phase1.png)
 
+One caveat with the use of a user-space filesystem is the requirement
+of user read and write file permissions in order to check and update
+the extended attributes which maintain the projection state of a given
+file or directory.
+
+Whereas an in-kernel implementation may read and set attributes in
+the `trusted.*` namespace, and do so at will, a user-space filesystem
+is restricted to the use of the `user.*` extended attribute namespace,
+and, further, can only read and change attributes as allowed by the file
+permission modes of a given inode.  Thus in order to test whether
+a given file or directory is a placeholder, the user must have read
+permission, so a write-only file mode like `0222` can not be permitted.
+And user write permissions must be assigned to any read-only files or
+directories, at least temporarily, in order to convert them from the
+placeholder state to another (i.e., hydrated or full).
+
 ### Phase 2 – Hybrid
 
 The second development phase adds an in-kernel projfs module which, at first,

--- a/include/projfs.h
+++ b/include/projfs.h
@@ -31,10 +31,6 @@
 
 #include "projfs_notify.h"
 
-// TODO: remove when not needed
-#define FUSE_USE_VERSION 32
-#include <fuse3/fuse_lowlevel.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -634,7 +634,8 @@ static int project_file(const char *op, const char *path,
 	 * which we want to ignore, and request a write mode so we receive
 	 * EISDIR if path is a directory.
 	 */
-	res = acquire_proj_state_lock(&state_lock, path, O_RDWR | O_NOFOLLOW);
+	res = acquire_proj_state_lock(&state_lock, path,
+				      O_RDWR | O_NOFOLLOW | O_NONBLOCK);
 	if (res != 0) {
 		if (res == ELOOP)
 			return 0;
@@ -1990,7 +1991,7 @@ static int iter_attrs(struct projfs *fs, const char *path,
 	if (nattrs == 0)
 		return 0;
 
-	fd = openat(fs->lowerdir_fd, path, O_RDONLY | O_NOFOLLOW);
+	fd = openat(fs->lowerdir_fd, path, O_RDONLY | O_NOFOLLOW | O_NONBLOCK);
 	if (fd == -1)
 		return errno;
 

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -436,12 +436,11 @@ struct proj_state_lock {
  *
  * @param state_lock structure to fill out (zeroed by this function)
  * @param path path relative to lowerdir to lock and open
- * @param mode filemode to open path with; the fd populated in user will have
- *             this mode
+ * @param flags file flags with which to open the locked fd
  * @return 0 or an errno
  */
 static int acquire_proj_state_lock(struct proj_state_lock *state_lock,
-				   const char *path, mode_t mode)
+				   const char *path, int flags)
 {
 	enum proj_state state;
 	int err, wait_ms;
@@ -450,7 +449,7 @@ static int acquire_proj_state_lock(struct proj_state_lock *state_lock,
 	memset(state_lock, 0, sizeof(*state_lock));
 
 	state_lock->lock_fd = openat(get_fuse_context_lowerdir_fd(),
-				     path, mode);
+				     path, flags);
 	if (state_lock->lock_fd == -1)
 		return errno;
 

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -1638,7 +1638,8 @@ static void *projfs_loop(void *data)
 	/* open lower directory file descriptor to resolve relative paths
 	 * in file ops
 	 */
-	fs->lowerdir_fd = open(fs->lowerdir, O_DIRECTORY | O_NOFOLLOW);
+	fs->lowerdir_fd = open(fs->lowerdir,
+			       O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
 	if (fs->lowerdir_fd == -1) {
 		log_printf(fs, LOG_STDERR_FALLBACK,
 			   "failed to open lowerdir: %s: %s",

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -483,6 +483,7 @@ retry_flock:
 
 out_close:
 	close(state_lock->lock_fd);
+	state_lock->lock_fd = -1;
 	return err;
 }
 

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -43,7 +43,9 @@
 #include "fdtable.h"
 #include "projfs.h"
 
+#define FUSE_USE_VERSION 32
 #include <fuse3/fuse.h>
+#include <fuse3/fuse_lowlevel.h>
 
 // TODO: make this value configurable
 #define PROJ_WAIT_MSEC 5000
@@ -1965,7 +1967,7 @@ int projfs_create_proj_symlink(struct projfs *fs, const char *path,
 
 	if (!check_safe_rel_path(path))
 		return EINVAL;
-	
+
 	res = symlinkat(target, fs->lowerdir_fd, path);
 	if (res == -1)
 		return errno;

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -664,6 +664,9 @@ static int project_file(const char *op, const char *path,
 	int log = 0;
 	int fd, res;
 
+	if (state != PROJ_STATE_POPULATED && state != PROJ_STATE_MODIFIED)
+		return EINVAL;
+
 	/* Pass O_NOFOLLOW so we receive ELOOP if path is an existing symlink,
 	 * which we want to ignore.
 	 */
@@ -685,6 +688,12 @@ static int project_file(const char *op, const char *path,
 			res = EISDIR;
 		else
 			res = 0;
+		goto out_release;
+	}
+
+	// check after fstat() because we need to return EISDIR if not a file
+	if (state_lock.state == state ||
+	    state_lock.state == PROJ_STATE_MODIFIED) {
 		goto out_release;
 	}
 

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -713,6 +713,8 @@ static int project_file(const char *op, const char *path,
 		reset_mode = fchmod_user_write_stat(lock_fd, &st, 1);
 		if (!reset_mode)
 			goto out_release;
+		res = 0;
+
 		fd = open(self_fd_path, O_WRONLY | O_NONBLOCK);
 		if (fd == -1) {
 			res = errno;

--- a/lib/projfs.c
+++ b/lib/projfs.c
@@ -588,7 +588,7 @@ static int project_dir(const char *op, const char *path, int parent)
 		return errno;
 
 	res = acquire_proj_state_lock(&state_lock, lock_path,
-				      O_RDONLY | O_DIRECTORY);
+				      O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
 	if (res != 0)
 		goto out;
 
@@ -1911,7 +1911,8 @@ int projfs_create_proj_dir(struct projfs *fs, const char *path, mode_t mode,
 	if (mkdirat(fs->lowerdir_fd, path, mode) == -1)
 		return errno;
 
-	fd = openat(fs->lowerdir_fd, path, O_RDONLY);
+	fd = openat(fs->lowerdir_fd, path,
+		    O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
 	if (fd == -1)
 		return errno;
 
@@ -1989,7 +1990,7 @@ static int iter_attrs(struct projfs *fs, const char *path,
 	if (nattrs == 0)
 		return 0;
 
-	fd = openat(fs->lowerdir_fd, path, O_RDONLY);
+	fd = openat(fs->lowerdir_fd, path, O_RDONLY | O_NOFOLLOW);
 	if (fd == -1)
 		return errno;
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -47,6 +47,7 @@ TESTS = t000-mirror-read.t \
 	t005-mirror-links.t \
 	t006-mirror-statfs.t \
 	t007-mirror-attrs.t \
+	t008-mirror-perms.t \
 	t100-fdtable-fill.t \
 	t200-event-ok.t \
 	t201-event-err.t \

--- a/t/t008-mirror-perms.t
+++ b/t/t008-mirror-perms.t
@@ -1,0 +1,72 @@
+#!/bin/sh
+#
+# Copyright (C) 2018-2019 GitHub, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/ .
+
+test_description='projfs filesystem permission mode tests
+
+Check that user read file permission modes are enforced and
+sufficient for projection through a mirrored projfs mount.
+'
+
+. ./test-lib.sh
+
+umask 0000
+projfs_start test_simple source target || exit 1
+
+EXPECT_DIR="$TEST_DIRECTORY/$(basename "$0" .t | sed 's/-.*//')"
+
+test_expect_success 'create target tree' '
+	mkdir -p target/d1 &&
+	mkdir -p -m 0333 target/d1/d2 &&
+	touch target/f1.txt &&
+	chmod 0444 target/f1.txt &&
+	umask 0444 &&
+	touch target/d1/f2.txt &&
+	umask 0000 &&
+	chmod 0555 target/d1 &&
+	mkfifo -m 0222 target/p1 &&
+	ln -s dummy target/l1
+'
+
+test_expect_success 'check user read permission enforced' '
+	test $(stat -c %04a target/d1) -eq 0555 &&
+	test $(stat -c %04a target/d1/d2) -eq 0733 &&
+	test $(stat -c %04a target/f1.txt) -eq 0444 &&
+	test $(stat -c %04a target/d1/f2.txt) -eq 0622 &&
+	test $(stat -c %04a target/p1) -eq 0622
+'
+
+test_expect_success 'check projection test requires only read permission' '
+	mv target/d1 target/d1a &&
+	mv target/f1.txt target/f1a.txt
+'
+
+test_expect_success 'check projection test does not block' '
+	mv target/p1 target/p1a
+'
+
+test_expect_success 'check projection test does not follow links' '
+	mv target/l1 target/l1a
+'
+
+test_expect_success 'reset write permissions' '
+	chmod -R u+w target
+'
+
+projfs_stop || exit 1
+
+test_done
+

--- a/t/test_handlers.c
+++ b/t/test_handlers.c
@@ -20,6 +20,7 @@
 */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/t/wait_mount.c
+++ b/t/wait_mount.c
@@ -24,6 +24,7 @@
 #include <err.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
 


### PR DESCRIPTION
When any file happens to have read-only permissions, any file operation which calls `project_file()` to ensure it has been populated with content (such as `open(2)` and many others) will fail, because we try to open the file with `O_RDWR`.  Instead, we now only require read permissions and open the file with `O_RDONLY` when acquiring a lock on it in `project_file()`.  If the file needs to be populated, we then re-open it with `O_WRONLY`, after temporarily adding user write permission with `fchmod(2)` if necessary.  Similarly, if we determine that a directory needs to be populated in `project_dir()`, we temporarily add user write permissions if necessary.

We only check user write permissions (`S_IWUSR`) because, if the file or directory is not owned by the current effective user, then `fchmod()` would fail anyway (assuming we're not a privileged user), so we wouldn't be able to add any additional permissions, and if the file or directory _is_ owned by the current effective user, then only `S_IWUSR` is checked when determining access since only the [best-matching class's permissions are checked](https://en.wikipedia.org/wiki/File_system_permissions#Classes) and there is no fall-through to other classes (i.e., `S_IWGRP` or `S_IWOTH`).  And since we are running a FUSE filesystem without the `allow_other` option, we can generally expect to [not be running](https://github.com/libfuse/libfuse#security-implications) as `root` or in a privileged state.

Therefore our `fchmod_user_write()` helper function therefore has a simplified version of the `uid` and mode tests [implemented](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/faccessat.c;h=a5891f43c299b107ee50af7e91d72df4c4a1bee2;hb=HEAD#l59) for glibc's `faccessat(2)` function.

When creating empty files or directories as placeholders in the `projfs_create_proj_file/dir()` functions, we also want to ensure that we have, at least temporarily, write permissions, so the `fsetxattr()` calls succeed.

We always open file descriptors using `O_NONBLOCK` to ensure that if the inode actually happens to be a FIFO, we won't block indefinitely until some data is written to the pipe.  If this happens, the process which happened to trigger the projection, perhaps by innocently trying to read a not-yet-projected empty file, will enter the dreaded uninterruptable state while it waits for its syscall to complete.

We should not follow symlinks when projecting or setting/reading projection xattrs, as the symlink may be broken, or lead out of our mount point.

Separately, make our use of libfuse's headers completely internal; there is no need to require our clients to include them, as our API is independent.

Resolves #72, resolves github/VFSForGit#23.