### PR TITLE
add move permission and delete notification events

### DIFF
--- a/include/projfs_notify.h
+++ b/include/projfs_notify.h
@@ -39,8 +39,11 @@ extern "C" {
 #define PROJFS_CLOSE_WRITE	0x00000008	/* Writable file closed */
 #define PROJFS_MOVE		0x000000C0	/* File/dir moved (TO+FROM) */
 #define PROJFS_CREATE		0x00000100	/* File/dir created */
+#define PROJFS_DELETE		0x00000200	/* File/dir deleted */
 #define PROJFS_OPEN_PERM	0x00010000	/* File open perm (wr only) */
-#define PROJFS_DELETE_PERM	himask(0x0001)	/* Delete permission */
+						/* Create perm (future) */
+#define PROJFS_DELETE_PERM	himask(0x0002)	/* Delete permission */
+#define PROJFS_MOVE_PERM	himask(0x0004)	/* Move permission */
 
 /** Filesystem event flags */
 #define PROJFS_ONDIR		0x40000000	/* Event occurred on dir */
@@ -78,6 +81,7 @@ extern "C" {
 #if (PROJFS_CLOSE_WRITE	!= IN_CLOSE_WRITE ||	\
      PROJFS_MOVE	!= IN_MOVE ||	\
      PROJFS_CREATE	!= IN_CREATE ||	\
+     PROJFS_DELETE	!= IN_DELETE ||	\
      PROJFS_ONDIR	!= IN_ISDIR)
 #error "Projfs notification API out of sync with sys/inotify.h API"
 #endif

--- a/t/t200-event-ok.t
+++ b/t/t200-event-ok.t
@@ -56,11 +56,13 @@ test_expect_success 'test event handler on nested file creation' '
 '
 
 projfs_event_printf perm delete_file d1/d2/f2.txt
+projfs_event_printf notify delete_file d1/d2/f2.txt
 test_expect_success 'test permission granted on nested file deletion' '
 	projfs_event_exec rm target/d1/d2/f2.txt &&
 	test_path_is_missing target/d1/d2/f2.txt
 '
 
+projfs_event_printf perm rename_file f1.txt f1a.txt
 projfs_event_printf notify rename_file f1.txt f1a.txt
 test_expect_success 'test event handler on file rename' '
 	projfs_event_exec mv target/f1.txt target/f1a.txt &&
@@ -75,11 +77,13 @@ test_expect_success 'test event handler on file hard link' '
 '
 
 projfs_event_printf perm delete_file f1a.txt
+projfs_event_printf notify delete_file f1a.txt
 test_expect_success 'test permission granted on top-level file deletion' '
 	projfs_event_exec rm target/f1a.txt &&
 	test_path_is_missing target/f1a.txt
 '
 
+projfs_event_printf perm rename_dir d1/d2 d1/d2a
 projfs_event_printf notify rename_dir d1/d2 d1/d2a
 test_expect_success 'test event handler on directory rename' '
 	projfs_event_exec mv target/d1/d2 target/d1/d2a &&
@@ -88,12 +92,14 @@ test_expect_success 'test event handler on directory rename' '
 '
 
 projfs_event_printf perm delete_dir d1/d2a
+projfs_event_printf notify delete_dir d1/d2a
 test_expect_success 'test permission granted on nested directory deletion' '
 	projfs_event_exec rmdir target/d1/d2a &&
 	test_path_is_missing target/d1/d2a
 '
 
 projfs_event_printf perm delete_dir d1
+projfs_event_printf notify delete_dir d1
 test_expect_success 'test permission granted on parent directory deletion' '
 	projfs_event_exec rmdir target/d1 &&
 	test_path_is_missing target/d1

--- a/t/t201-event-err.t
+++ b/t/t201-event-err.t
@@ -45,40 +45,36 @@ test_expect_success 'test event handler error on file creation' '
 	test_path_is_file target/f1.txt
 '
 
-# TODO: we expect mv to rename a dir despite the handler error and
-#	to not report a failure exit code
-projfs_event_printf error ENOMEM notify rename_dir d1 d1a
+projfs_event_printf error ENOMEM perm rename_dir d1 d1a
 test_expect_success 'test event handler error on directory rename' '
-	test_might_fail projfs_event_exec mv target/d1 target/d1a &&
-	test_path_is_dir target/d1a
+	test_must_fail projfs_event_exec mv target/d1 target/d1a &&
+	test_path_is_dir target/d1
 '
 
-# TODO: we expect mv to rename a file despite the handler error and
-#	to not report a failure exit code
-projfs_event_printf error ENOMEM notify rename_file f1.txt f1a.txt
+projfs_event_printf error ENOMEM perm rename_file f1.txt f1a.txt
 test_expect_success 'test event handler error on file rename' '
-	test_might_fail projfs_event_exec mv target/f1.txt target/f1a.txt &&
-	test_path_is_file target/f1a.txt
+	test_must_fail projfs_event_exec mv target/f1.txt target/f1a.txt &&
+	test_path_is_file target/f1.txt
 '
 
 # TODO: we expect ln to link a file despite the handler error and
 #	to not report a failure exit code
-projfs_event_printf error ENOMEM notify link_file f1a.txt l1a.txt
+projfs_event_printf error ENOMEM notify link_file f1.txt l1.txt
 test_expect_success 'test event handler error on file hard link' '
-	test_might_fail projfs_event_exec ln target/f1a.txt target/l1a.txt &&
-	test_path_is_file target/l1a.txt
+	test_might_fail projfs_event_exec ln target/f1.txt target/l1.txt &&
+	test_path_is_file target/l1.txt
 '
 
-projfs_event_printf error ENOMEM perm delete_file f1a.txt
+projfs_event_printf error ENOMEM perm delete_file f1.txt
 test_expect_success 'test event handler error on file deletion' '
-	test_must_fail projfs_event_exec rm target/f1a.txt &&
-	test_path_is_file target/f1a.txt
+	test_must_fail projfs_event_exec rm target/f1.txt &&
+	test_path_is_file target/f1.txt
 '
 
-projfs_event_printf error ENOMEM perm delete_dir d1a
+projfs_event_printf error ENOMEM perm delete_dir d1
 test_expect_success 'test event handler error on directory deletion' '
-	test_must_fail projfs_event_exec rmdir target/d1a &&
-	test_path_is_dir target/d1a
+	test_must_fail projfs_event_exec rmdir target/d1 &&
+	test_path_is_dir target/d1
 '
 
 rm retval

--- a/t/t202-event-deny.t
+++ b/t/t202-event-deny.t
@@ -40,36 +40,36 @@ test_expect_success 'test event handler on file creation' '
 	test_path_is_file target/f1.txt
 '
 
-projfs_event_printf notify rename_dir d1 d1a
-test_expect_success 'test event handler on directory rename' '
-	projfs_event_exec mv target/d1 target/d1a &&
-	test_path_is_missing target/d1 &&
-	test_path_is_dir target/d1a
+projfs_event_printf perm rename_dir d1 d1a
+test_expect_success 'test permission request denied on directory rename' '
+	test_must_fail projfs_event_exec mv target/d1 target/d1a &&
+	test_path_is_missing target/d1a &&
+	test_path_is_dir target/d1
 '
 
-projfs_event_printf notify rename_file f1.txt f1a.txt
-test_expect_success 'test event handler on file rename' '
-	projfs_event_exec mv target/f1.txt target/f1a.txt &&
-	test_path_is_missing target/f1.txt &&
-	test_path_is_file target/f1a.txt
+projfs_event_printf perm rename_file f1.txt f1a.txt
+test_expect_success 'test permission request denied on file rename' '
+	test_must_fail projfs_event_exec mv target/f1.txt target/f1a.txt &&
+	test_path_is_missing target/f1a.txt &&
+	test_path_is_file target/f1.txt
 '
 
-projfs_event_printf notify link_file f1a.txt l1a.txt
+projfs_event_printf notify link_file f1.txt l1.txt
 test_expect_success 'test event handler on file hard link' '
-	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
-	test_path_is_file target/l1a.txt
+	projfs_event_exec ln target/f1.txt target/l1.txt &&
+	test_path_is_file target/l1.txt
 '
 
-projfs_event_printf perm delete_file f1a.txt
+projfs_event_printf perm delete_file f1.txt
 test_expect_success 'test permission request denied on file deletion' '
-	test_must_fail projfs_event_exec rm target/f1a.txt &&
-	test_path_is_file target/f1a.txt
+	test_must_fail projfs_event_exec rm target/f1.txt &&
+	test_path_is_file target/f1.txt
 '
 
-projfs_event_printf perm delete_dir d1a
+projfs_event_printf perm delete_dir d1
 test_expect_success 'test permission request denied on directory deletion' '
-	test_must_fail projfs_event_exec rmdir target/d1a &&
-	test_path_is_dir target/d1a
+	test_must_fail projfs_event_exec rmdir target/d1 &&
+	test_path_is_dir target/d1
 '
 
 rm retval

--- a/t/t203-event-null.t
+++ b/t/t203-event-null.t
@@ -40,36 +40,36 @@ test_expect_success 'test event handler on file creation' '
 	test_path_is_file target/f1.txt
 '
 
-projfs_event_printf notify rename_dir d1 d1a
-test_expect_success 'test event handler on directory rename' '
-	projfs_event_exec mv target/d1 target/d1a &&
-	test_path_is_missing target/d1 &&
-	test_path_is_dir target/d1a
+projfs_event_printf perm rename_dir d1 d1a
+test_expect_success 'test permission request denied on directory rename' '
+	test_must_fail projfs_event_exec mv target/d1 target/d1a &&
+	test_path_is_missing target/d1a &&
+	test_path_is_dir target/d1
 '
 
-projfs_event_printf notify rename_file f1.txt f1a.txt
-test_expect_success 'test event handler on file rename' '
-	projfs_event_exec mv target/f1.txt target/f1a.txt &&
-	test_path_is_missing target/f1.txt &&
-	test_path_is_file target/f1a.txt
+projfs_event_printf perm rename_file f1.txt f1a.txt
+test_expect_success 'test permission request denied on file rename' '
+	test_must_fail projfs_event_exec mv target/f1.txt target/f1a.txt &&
+	test_path_is_missing target/f1a.txt &&
+	test_path_is_file target/f1.txt
 '
 
-projfs_event_printf notify link_file f1a.txt l1a.txt
+projfs_event_printf notify link_file f1.txt l1.txt
 test_expect_success 'test event handler on file hard link' '
-	projfs_event_exec ln target/f1a.txt target/l1a.txt &&
-	test_path_is_file target/l1a.txt
+	projfs_event_exec ln target/f1.txt target/l1.txt &&
+	test_path_is_file target/l1.txt
 '
 
-projfs_event_printf perm delete_file f1a.txt
+projfs_event_printf perm delete_file f1.txt
 test_expect_success 'test permission request denied on file deletion' '
-	test_must_fail projfs_event_exec rm target/f1a.txt &&
-	test_path_is_file target/f1a.txt
+	test_must_fail projfs_event_exec rm target/f1.txt &&
+	test_path_is_file target/f1.txt
 '
 
-projfs_event_printf perm delete_dir d1a
+projfs_event_printf perm delete_dir d1
 test_expect_success 'test permission request denied on directory deletion' '
-	test_must_fail projfs_event_exec rmdir target/d1a &&
-	test_path_is_dir target/d1a
+	test_must_fail projfs_event_exec rmdir target/d1 &&
+	test_path_is_dir target/d1
 '
 
 rm retval

--- a/t/t204-event-allow.t
+++ b/t/t204-event-allow.t
@@ -40,6 +40,7 @@ test_expect_success 'test event handler on file creation' '
 	test_path_is_file target/f1.txt
 '
 
+projfs_event_printf perm rename_dir d1 d1a
 projfs_event_printf notify rename_dir d1 d1a
 test_expect_success 'test event handler on directory rename' '
 	projfs_event_exec mv target/d1 target/d1a &&
@@ -47,6 +48,7 @@ test_expect_success 'test event handler on directory rename' '
 	test_path_is_dir target/d1a
 '
 
+projfs_event_printf perm rename_file f1.txt f1a.txt
 projfs_event_printf notify rename_file f1.txt f1a.txt
 test_expect_success 'test event handler on file rename' '
 	projfs_event_exec mv target/f1.txt target/f1a.txt &&
@@ -61,12 +63,14 @@ test_expect_success 'test event handler on file hard link' '
 '
 
 projfs_event_printf perm delete_file f1a.txt
+projfs_event_printf notify delete_file f1a.txt
 test_expect_success 'test permission request allowed on file deletion' '
 	projfs_event_exec rm target/f1a.txt &&
 	test_path_is_missing target/f1a.txt
 '
 
 projfs_event_printf perm delete_dir d1a
+projfs_event_printf notify delete_dir d1a
 test_expect_success 'test permission request allowed on directory deletion' '
 	projfs_event_exec rmdir target/d1a &&
 	test_path_is_missing target/d1a

--- a/t/test-lib-event.sh
+++ b/t/test-lib-event.sh
@@ -23,15 +23,21 @@ event_msg_perm="test permission request for"
 
 event_msg_err="event handler failed"
 
-event_rename_dir="0x0000-400000c0"
-event_create_dir="0x0000-40000100"
-event_delete_dir="0x0001-40000000"
+event_notify_close_file="0x0000-00000008"
+event_notify_rename_file="0x0000-000000c0"
+event_notify_create_file="0x0000-00000100"
+event_notify_delete_file="0x0000-00000200"
+event_notify_link_file="0x1000-00000100"
 
-event_close_file="0x0000-00000008"
-event_rename_file="0x0000-000000c0"
-event_create_file="0x0000-00000100"
-event_delete_file="0x0001-00000000"
-event_link_file="0x1000-00000100"
+event_notify_rename_dir="0x0000-400000c0"
+event_notify_create_dir="0x0000-40000100"
+event_notify_delete_dir="0x0000-40000200"
+
+event_perm_delete_file="0x0002-00000000"
+event_perm_rename_file="0x0004-00000000"
+
+event_perm_delete_dir="0x0002-40000000"
+event_perm_rename_dir="0x0004-40000000"
 
 NL=$(printf "\nx")
 NL="${NL%%x}"
@@ -59,7 +65,7 @@ projfs_event_printf () {
 	fi
 
 	eval msg=\$event_msg_"$1"
-	eval code=\$event_"$2"
+	eval code=\$event_"$1"_"$2"
 
 	if test -z "$4"
 	then


### PR DESCRIPTION
Previously, deletion operations (`rmdir` and `unlink`) sent a permission request event, but no notification event after successful deletion.  Rename operations did the opposite, sending only a notification event after a successful move.

In order to fully support VFSForGit, and to treat these two forms of filesystem modification similarly, we issue both a permission request beforehand, and if the request is granted and the operation successful, a subsequent informational event notification.

We also shift the value of `PROJFS_DELETE_PERM` left by one bit to leave room in case `PROJFS_CREATE_PERM` is ever needed in the future.